### PR TITLE
Tests concise GoogleTest assertion failures

### DIFF
--- a/test/uvw/async.cpp
+++ b/test/uvw/async.cpp
@@ -37,7 +37,7 @@ TEST(Async, Fake) {
     auto loop = uvw::Loop::getDefault();
     auto handle = loop->resource<uvw::AsyncHandle>();
 
-    auto l = [](const auto &, auto &) { ASSERT_FALSE(true); };
+    auto l = [](const auto &, auto &) { FAIL(); };
     handle->on<uvw::ErrorEvent>(l);
     handle->on<uvw::AsyncEvent>(l);
 

--- a/test/uvw/check.cpp
+++ b/test/uvw/check.cpp
@@ -38,7 +38,7 @@ TEST(Check, Fake) {
     auto loop = uvw::Loop::getDefault();
     auto handle = loop->resource<uvw::CheckHandle>();
 
-    auto l = [](const auto &, auto &) { ASSERT_FALSE(true); };
+    auto l = [](const auto &, auto &) { FAIL(); };
     handle->on<uvw::ErrorEvent>(l);
     handle->on<uvw::CheckEvent>(l);
 

--- a/test/uvw/idle.cpp
+++ b/test/uvw/idle.cpp
@@ -38,7 +38,7 @@ TEST(Idle, Fake) {
     auto loop = uvw::Loop::getDefault();
     auto handle = loop->resource<uvw::IdleHandle>();
 
-    auto l = [](const auto &, auto &) { ASSERT_FALSE(true); };
+    auto l = [](const auto &, auto &) { FAIL(); };
     handle->on<uvw::ErrorEvent>(l);
     handle->on<uvw::IdleEvent>(l);
 

--- a/test/uvw/loop.cpp
+++ b/test/uvw/loop.cpp
@@ -9,13 +9,13 @@ TEST(Loop, PartiallyDone) {
     ASSERT_FALSE(def->alive());
     ASSERT_NO_THROW(def->stop());
 
-    def->walk([](uvw::BaseHandle &) { ASSERT_TRUE(false); });
+    def->walk([](uvw::BaseHandle &) { FAIL(); });
 
     auto loop = uvw::Loop::create();
     auto handle = loop->resource<uvw::PrepareHandle>();
-    auto req = loop->resource<uvw::WorkReq>([]() {});
+    auto req = loop->resource<uvw::WorkReq>([]{});
 
-    auto err = [](const auto &, auto &) { ASSERT_TRUE(false); };
+    auto err = [](const auto &, auto &) { FAIL(); };
 
     loop->on<uvw::ErrorEvent>(err);
     req->on<uvw::ErrorEvent>(err);
@@ -40,7 +40,7 @@ TEST(Loop, PartiallyDone) {
     ASSERT_TRUE(loop->alive());
     ASSERT_NO_THROW(loop->run());
 
-    loop->walk([](uvw::BaseHandle &) { ASSERT_TRUE(false); });
+    loop->walk([](uvw::BaseHandle &) { FAIL(); });
 
     ASSERT_NO_THROW(loop->run<uvw::Loop::Mode::ONCE>());
     ASSERT_NO_THROW(loop->run<uvw::Loop::Mode::NOWAIT>());

--- a/test/uvw/prepare.cpp
+++ b/test/uvw/prepare.cpp
@@ -38,7 +38,7 @@ TEST(Prepare, Fake) {
     auto loop = uvw::Loop::getDefault();
     auto handle = loop->resource<uvw::PrepareHandle>();
 
-    auto l = [](const auto &, auto &) { ASSERT_FALSE(true); };
+    auto l = [](const auto &, auto &) { FAIL(); };
     handle->on<uvw::ErrorEvent>(l);
     handle->on<uvw::PrepareEvent>(l);
 

--- a/test/uvw/signal.cpp
+++ b/test/uvw/signal.cpp
@@ -6,7 +6,7 @@ TEST(Signal, Fake) {
     auto loop = uvw::Loop::getDefault();
     auto handle = loop->resource<uvw::SignalHandle>();
 
-    auto l = [](const auto &, auto &) { ASSERT_FALSE(true); };
+    auto l = [](const auto &, auto &) { FAIL(); };
     handle->on<uvw::ErrorEvent>(l);
     handle->on<uvw::CheckEvent>(l);
 

--- a/test/uvw/timer.cpp
+++ b/test/uvw/timer.cpp
@@ -115,7 +115,7 @@ TEST(Timer, Fake) {
     auto loop = uvw::Loop::getDefault();
     auto handle = loop->resource<uvw::TimerHandle>();
 
-    auto l = [](const auto &, auto &) { ASSERT_FALSE(true); };
+    auto l = [](const auto &, auto &) { FAIL(); };
     handle->on<uvw::ErrorEvent>(l);
     handle->on<uvw::TimerEvent>(l);
 


### PR DESCRIPTION
GoogleTest defines a `FAIL` macro which is a concise way of making an assert failure.<br />Note that these assertion failures (in lambda expressions) are non-fatal unlike their usual usage.