### PR TITLE
Cleanup

### DIFF
--- a/src/uvw/async.hpp
+++ b/src/uvw/async.hpp
@@ -67,7 +67,7 @@ public:
      * for further details.
      */
     void send() {
-        invoke(&uv_async_send, get<uv_async_t>());
+        invoke(&uv_async_send, get());
     }
 };
 

--- a/src/uvw/async.hpp
+++ b/src/uvw/async.hpp
@@ -53,7 +53,7 @@ public:
      * @return True in case of success, false otherwise.
      */
     bool init() {
-        return initialize<uv_async_t>(&uv_async_init, &sendCallback);
+        return initialize(&uv_async_init, &sendCallback);
     }
 
     /**

--- a/src/uvw/check.hpp
+++ b/src/uvw/check.hpp
@@ -59,14 +59,14 @@ public:
      * polling for I/O.
      */
     void start() {
-        invoke(&uv_check_start, get<uv_check_t>(), &startCallback);
+        invoke(&uv_check_start, get(), &startCallback);
     }
 
     /**
      * @brief Stops the handle.
      */
     void stop() {
-        invoke(&uv_check_stop, get<uv_check_t>());
+        invoke(&uv_check_stop, get());
     }
 };
 

--- a/src/uvw/check.hpp
+++ b/src/uvw/check.hpp
@@ -49,7 +49,7 @@ public:
      * @return True in case of success, false otherwise.
      */
     bool init() {
-        return initialize<uv_check_t>(&uv_check_init);
+        return initialize(&uv_check_init);
     }
 
     /**

--- a/src/uvw/dns.hpp
+++ b/src/uvw/dns.hpp
@@ -98,11 +98,11 @@ class GetAddrInfoReq final: public Request<GetAddrInfoReq, uv_getaddrinfo_t> {
     using Request::Request;
 
     void getNodeAddrInfo(const char *node, const char *service, addrinfo *hints = nullptr) {
-        invoke(&uv_getaddrinfo, parent(), get<uv_getaddrinfo_t>(), &getAddrInfoCallback, node, service, hints);
+        invoke(&uv_getaddrinfo, parent(), get(), &getAddrInfoCallback, node, service, hints);
     }
 
     auto getNodeAddrInfoSync(const char *node, const char *service, addrinfo *hints = nullptr) {
-        auto req = get<uv_getaddrinfo_t>();
+        auto req = get();
         auto err = uv_getaddrinfo(parent(), req, nullptr, node, service, hints);
         auto ptr = std::unique_ptr<addrinfo, void(*)(addrinfo *)>{req->addrinfo, [](addrinfo *res){ uv_freeaddrinfo(res); }};
         return std::make_pair(ErrorEvent{err}, AddrInfoEvent{std::move(ptr)});
@@ -217,7 +217,7 @@ public:
     void getNameInfo(std::string ip, unsigned int port, int flags = 0) {
         typename details::IpTraits<I>::Type addr;
         details::IpTraits<I>::AddrFunc(ip.data(), port, &addr);
-        invoke(&uv_getnameinfo, parent(), get<uv_getnameinfo_t>(), &getNameInfoCallback, &addr, flags);
+        invoke(&uv_getnameinfo, parent(), get(), &getNameInfoCallback, &addr, flags);
     }
 
     /**
@@ -240,7 +240,7 @@ public:
     auto getNameInfoSync(std::string ip, unsigned int port, int flags = 0) {
         typename details::IpTraits<I>::Type addr;
         details::IpTraits<I>::AddrFunc(ip.data(), port, &addr);
-        auto req = get<uv_getnameinfo_t>();
+        auto req = get();
         auto err = uv_getnameinfo(parent(), req, nullptr, &addr, flags);
         return std::make_pair(ErrorEvent{err}, NameInfoEvent{req->host, req->service});
     }

--- a/src/uvw/emitter.hpp
+++ b/src/uvw/emitter.hpp
@@ -177,7 +177,9 @@ public:
      */
     void clearAll() noexcept {
         for(auto &&h: handlers) {
-            h->clear();
+            if (h) {
+                h->clear();
+            }
         }
     }
 
@@ -192,7 +194,7 @@ public:
 
         return (!(type < handlers.size()) ||
                 !handlers[type] ||
-                static_cast<Handler<E>&>(*handlers[type]).empty());
+                handlers[type]->empty());
     }
 
     /**

--- a/src/uvw/emitter.hpp
+++ b/src/uvw/emitter.hpp
@@ -7,7 +7,6 @@
 #include <cstddef>
 #include <vector>
 #include <memory>
-#include <tuple>
 #include <list>
 #include "event.hpp"
 

--- a/src/uvw/emitter.hpp
+++ b/src/uvw/emitter.hpp
@@ -177,9 +177,7 @@ public:
      */
     void clearAll() noexcept {
         for(auto &&h: handlers) {
-            if (h) {
-                h->clear();
-            }
+            h->clear();
         }
     }
 
@@ -194,7 +192,7 @@ public:
 
         return (!(type < handlers.size()) ||
                 !handlers[type] ||
-                handlers[type]->empty());
+                static_cast<Handler<E>&>(*handlers[type]).empty());
     }
 
     /**

--- a/src/uvw/fs.hpp
+++ b/src/uvw/fs.hpp
@@ -428,13 +428,13 @@ protected:
 
     template<typename... Args>
     void cleanupAndInvoke(Args&&... args) {
-        uv_fs_req_cleanup(get());
+        uv_fs_req_cleanup(this->get());
         this->invoke(std::forward<Args>(args)...);
     }
 
     template<typename F, typename... Args>
     void cleanupAndInvokeSync(F &&f, Args&&... args) {
-        uv_fs_req_cleanup(get());
+        uv_fs_req_cleanup(this->get());
         std::forward<F>(f)(std::forward<Args>(args)..., nullptr);
     }
 

--- a/src/uvw/fs_event.hpp
+++ b/src/uvw/fs_event.hpp
@@ -109,7 +109,7 @@ public:
      * @return True in case of success, false otherwise.
      */
     bool init() {
-        return initialize<uv_fs_event_t>(&uv_fs_event_init);
+        return initialize(&uv_fs_event_init);
     }
 
     /**

--- a/src/uvw/fs_event.hpp
+++ b/src/uvw/fs_event.hpp
@@ -130,7 +130,7 @@ public:
      * @param flags Additional flags to control the behavior.
      */
     void start(std::string path, Flags<Watch> flags = Flags<Watch>{}) {
-        invoke(&uv_fs_event_start, get<uv_fs_event_t>(), &startCallback, path.data(), flags);
+        invoke(&uv_fs_event_start, get(), &startCallback, path.data(), flags);
     }
 
     /**
@@ -158,7 +158,7 @@ public:
      * @brief Stops polling the file descriptor.
      */
     void stop() {
-        invoke(&uv_fs_event_stop, get<uv_fs_event_t>());
+        invoke(&uv_fs_event_stop, get());
     }
 
     /**
@@ -166,7 +166,7 @@ public:
      * @return The path being monitored.
      */
     std::string path() noexcept {
-        return details::path(&uv_fs_event_getpath, get<uv_fs_event_t>());
+        return details::path(&uv_fs_event_getpath, get());
     }
 };
 

--- a/src/uvw/fs_poll.hpp
+++ b/src/uvw/fs_poll.hpp
@@ -85,14 +85,14 @@ public:
      * @param interval Milliseconds between successive checks.
      */
     void start(std::string file, unsigned int interval) {
-        invoke(&uv_fs_poll_start, get<uv_fs_poll_t>(), &startCallback, file.data(), interval);
+        invoke(&uv_fs_poll_start, get(), &startCallback, file.data(), interval);
     }
 
     /**
      * @brief Stops the handle.
      */
     void stop() {
-        invoke(&uv_fs_poll_stop, get<uv_fs_poll_t>());
+        invoke(&uv_fs_poll_stop, get());
     }
 
     /**
@@ -100,7 +100,7 @@ public:
      * @return The path being monitored by the handle.
      */
     std::string path() noexcept {
-        return details::path(&uv_fs_poll_getpath, get<uv_fs_poll_t>());
+        return details::path(&uv_fs_poll_getpath, get());
     }
 };
 

--- a/src/uvw/fs_poll.hpp
+++ b/src/uvw/fs_poll.hpp
@@ -73,7 +73,7 @@ public:
      * @return True in case of success, false otherwise.
      */
     bool init() {
-        return initialize<uv_fs_poll_t>(&uv_fs_poll_init);
+        return initialize(&uv_fs_poll_init);
     }
 
     /**

--- a/src/uvw/handle.hpp
+++ b/src/uvw/handle.hpp
@@ -43,10 +43,10 @@ protected:
         *buf = uv_buf_init(new char[suggested], suggested);
     }
 
-    template<typename H, typename F, typename... Args>
+    template<typename F, typename... Args>
     bool initialize(F &&f, Args&&... args) {
         if(!this->self()) {
-            auto err = std::forward<F>(f)(this->parent(), this->template get<H>(), std::forward<Args>(args)...);
+            auto err = std::forward<F>(f)(this->parent(), this->get(), std::forward<Args>(args)...);
 
             if(err) {
                 this->publish(ErrorEvent{err});

--- a/src/uvw/idle.hpp
+++ b/src/uvw/idle.hpp
@@ -66,14 +66,14 @@ public:
      * polling the PrepareHandle handles.
      */
     void start() {
-        invoke(&uv_idle_start, get<uv_idle_t>(), &startCallback);
+        invoke(&uv_idle_start, get(), &startCallback);
     }
 
     /**
      * @brief Stops the handle.
      */
     void stop() {
-        invoke(&uv_idle_stop, get<uv_idle_t>());
+        invoke(&uv_idle_stop, get());
     }
 };
 

--- a/src/uvw/idle.hpp
+++ b/src/uvw/idle.hpp
@@ -56,7 +56,7 @@ public:
      * @return True in case of success, false otherwise.
      */
     bool init() {
-        return initialize<uv_idle_t>(&uv_idle_init);
+        return initialize(&uv_idle_init);
     }
 
     /**

--- a/src/uvw/lib.hpp
+++ b/src/uvw/lib.hpp
@@ -4,21 +4,12 @@
 #include <utility>
 #include <memory>
 #include <string>
+#include <type_traits>
 #include <uv.h>
 #include "loop.hpp"
 
 
 namespace uvw {
-
-
-namespace details {
-
-
-template<typename T> struct IsFunc: std::false_type { };
-template<typename R, typename... A> struct IsFunc<R(A...)>: std::true_type { };
-
-
-}
 
 
 /**
@@ -73,7 +64,7 @@ public:
      */
     template<typename F>
     F * sym(std::string name) {
-        static_assert(details::IsFunc<F>::value, "!");
+        static_assert(std::is_function<F>::value, "!");
         F *func;
         auto err = uv_dlsym(&lib, name.data(), reinterpret_cast<void**>(&func));
         if(err) { func = nullptr; }

--- a/src/uvw/lib.hpp
+++ b/src/uvw/lib.hpp
@@ -6,7 +6,6 @@
 #include <string>
 #include <uv.h>
 #include "loop.hpp"
-#include "loop.hpp"
 
 
 namespace uvw {

--- a/src/uvw/pipe.hpp
+++ b/src/uvw/pipe.hpp
@@ -44,7 +44,7 @@ public:
      * @return True in case of success, false otherwise.
      */
     bool init() {
-        return initialize<uv_pipe_t>(&uv_pipe_init, ipc);
+        return initialize(&uv_pipe_init, ipc);
     }
 
     /**

--- a/src/uvw/pipe.hpp
+++ b/src/uvw/pipe.hpp
@@ -56,7 +56,7 @@ public:
      * @param file A valid file handle (either a file descriptor or a HANDLE).
      */
     void open(FileHandle file) {
-        invoke(&uv_pipe_open, get<uv_pipe_t>(), file);
+        invoke(&uv_pipe_open, get(), file);
     }
 
     /**
@@ -67,7 +67,7 @@ public:
      * @param name A valid file path.
      */
     void bind(std::string name) {
-        invoke(&uv_pipe_bind, get<uv_pipe_t>(), name.data());
+        invoke(&uv_pipe_bind, get(), name.data());
     }
 
     /**
@@ -85,7 +85,7 @@ public:
         auto connect = loop().resource<details::ConnectReq>();
         connect->once<ErrorEvent>(listener);
         connect->once<ConnectEvent>(listener);
-        connect->connect(&uv_pipe_connect, get<uv_pipe_t>(), name.data());
+        connect->connect(&uv_pipe_connect, get(), name.data());
     }
 
     /**
@@ -93,7 +93,7 @@ public:
      * @return The name of the Unix domain socket or the named pipe.
      */
     std::string sock() const noexcept {
-        return details::path(&uv_pipe_getsockname, get<uv_pipe_t>());
+        return details::path(&uv_pipe_getsockname, get());
     }
 
     /**
@@ -103,7 +103,7 @@ public:
      * the handle is connected.
      */
     std::string peer() const noexcept {
-        return details::path(&uv_pipe_getpeername, get<uv_pipe_t>());
+        return details::path(&uv_pipe_getpeername, get());
     }
 
     /**
@@ -116,7 +116,7 @@ public:
      * @param count The number of accepted pending pipe.
      */
     void pending(int count) noexcept {
-        uv_pipe_pending_instances(get<uv_pipe_t>(), count);
+        uv_pipe_pending_instances(get(), count);
     }
 
     /**
@@ -124,7 +124,7 @@ public:
      * @return The number of pending pipe this instance can handle.
      */
     int pending() noexcept {
-        return uv_pipe_pending_count(get<uv_pipe_t>());
+        return uv_pipe_pending_count(get());
     }
 
     /**
@@ -144,7 +144,7 @@ public:
      * * `HandleType::UNKNOWN`
      */
     HandleType receive() noexcept {
-        auto type = uv_pipe_pending_type(get<uv_pipe_t>());
+        auto type = uv_pipe_pending_type(get());
         return Utilities::guessHandle(type);
     }
 

--- a/src/uvw/poll.hpp
+++ b/src/uvw/poll.hpp
@@ -109,8 +109,8 @@ public:
      */
     bool init() {
         return (tag == SOCKET)
-                ? initialize<uv_poll_t>(&uv_poll_init_socket, socket)
-                : initialize<uv_poll_t>(&uv_poll_init, fd);
+                ? initialize(&uv_poll_init_socket, socket)
+                : initialize(&uv_poll_init, fd);
     }
 
     /**

--- a/src/uvw/poll.hpp
+++ b/src/uvw/poll.hpp
@@ -132,7 +132,7 @@ public:
      * @param flags The events to which the caller is interested.
      */
     void start(Flags<Event> flags) {
-        invoke(&uv_poll_start, get<uv_poll_t>(), flags, &startCallback);
+        invoke(&uv_poll_start, get(), flags, &startCallback);
     }
 
     /**
@@ -161,7 +161,7 @@ public:
      * @brief Stops polling the file descriptor.
      */
     void stop() {
-        invoke(&uv_poll_stop, get<uv_poll_t>());
+        invoke(&uv_poll_stop, get());
     }
 
 private:

--- a/src/uvw/prepare.hpp
+++ b/src/uvw/prepare.hpp
@@ -61,14 +61,14 @@ public:
      * The handle will start emitting PrepareEvent when needed.
      */
     void start() {
-        invoke(&uv_prepare_start, get<uv_prepare_t>(), &startCallback);
+        invoke(&uv_prepare_start, get(), &startCallback);
     }
 
     /**
      * @brief Stops the handle.
      */
     void stop() {
-        invoke(&uv_prepare_stop, get<uv_prepare_t>());
+        invoke(&uv_prepare_stop, get());
     }
 };
 

--- a/src/uvw/prepare.hpp
+++ b/src/uvw/prepare.hpp
@@ -49,7 +49,7 @@ public:
      * @return True in case of success, false otherwise.
      */
     bool init() {
-        return initialize<uv_prepare_t>(&uv_prepare_init);
+        return initialize(&uv_prepare_init);
     }
 
     /**

--- a/src/uvw/process.hpp
+++ b/src/uvw/process.hpp
@@ -139,7 +139,7 @@ public:
         po.uid = poUid;
         po.gid = poGid;
 
-        invoke(&uv_spawn, parent(), get<uv_process_t>(), &po);
+        invoke(&uv_spawn, parent(), get(), &po);
     }
 
     /**
@@ -147,7 +147,7 @@ public:
      * @param signum A valid signal identifier.
      */
     void kill(int signum) {
-        invoke(&uv_process_kill, get<uv_process_t>(), signum);
+        invoke(&uv_process_kill, get(), signum);
     }
 
     /**
@@ -158,7 +158,7 @@ public:
      * @return The PID of the spawned process.
      */
     int pid() noexcept {
-        return get<uv_process_t>()->pid;
+        return get()->pid;
     }
 
     /**

--- a/src/uvw/request.hpp
+++ b/src/uvw/request.hpp
@@ -22,8 +22,8 @@ protected:
         return ptr;
     }
 
-    template<typename R, typename E>
-    static void defaultCallback(R *req, int status) {
+    template<typename E>
+    static void defaultCallback(U *req, int status) {
         auto ptr = reserve(reinterpret_cast<uv_req_t*>(req));
         if(status) { ptr->publish(ErrorEvent{status}); }
         else { ptr->publish(E{}); }

--- a/src/uvw/resource.hpp
+++ b/src/uvw/resource.hpp
@@ -36,13 +36,23 @@ protected:
         return pLoop->loop.get();
     }
 
-    template<typename R = U>
     auto get() noexcept {
+        return &resource;
+    }
+
+    const auto get() const noexcept {
+        return &resource;
+    }
+
+    template<typename R>
+    auto get() noexcept {
+        static_assert(not std::is_same<R, U>::value, "!");
         return reinterpret_cast<R*>(&resource);
     }
 
-    template<typename R = U>
+    template<typename R>
     auto get() const noexcept {
+        static_assert(not std::is_same<R, U>::value, "!");
         return reinterpret_cast<const R*>(&resource);
     }
 

--- a/src/uvw/resource.hpp
+++ b/src/uvw/resource.hpp
@@ -29,19 +29,19 @@ protected:
           pLoop{std::move(ref)},
           resource{}
     {
-        this->template get<U>()->data = static_cast<T*>(this);
+        resource.data = static_cast<T*>(this);
     }
 
     auto parent() const noexcept {
         return pLoop->loop.get();
     }
 
-    template<typename R>
+    template<typename R = U>
     auto get() noexcept {
         return reinterpret_cast<R*>(&resource);
     }
 
-    template<typename R>
+    template<typename R = U>
     auto get() const noexcept {
         return reinterpret_cast<const R*>(&resource);
     }

--- a/src/uvw/signal.hpp
+++ b/src/uvw/signal.hpp
@@ -65,7 +65,7 @@ public:
      * @return True in case of success, false otherwise.
      */
     bool init() {
-        return initialize<uv_signal_t>(&uv_signal_init);
+        return initialize(&uv_signal_init);
     }
 
     /**

--- a/src/uvw/signal.hpp
+++ b/src/uvw/signal.hpp
@@ -76,14 +76,14 @@ public:
      * @param signum The signal to be monitored.
      */
     void start(int signum) {
-        invoke(&uv_signal_start, get<uv_signal_t>(), &startCallback, signum);
+        invoke(&uv_signal_start, get(), &startCallback, signum);
     }
 
     /**
      * @brief Stops the handle.
      */
     void stop() {
-        invoke(&uv_signal_stop, get<uv_signal_t>());
+        invoke(&uv_signal_stop, get());
     }
 
     /**
@@ -91,7 +91,7 @@ public:
      * @return The signal being monitored.
      */
     int signal() const noexcept {
-        return get<uv_signal_t>()->signum;
+        return get()->signum;
     }
 };
 

--- a/src/uvw/stream.hpp
+++ b/src/uvw/stream.hpp
@@ -96,7 +96,7 @@ public:
 
     template<typename F, typename... Args>
     void connect(F &&f, Args... args) {
-        invoke(std::forward<F>(f), get(), std::forward<Args>(args)..., &defaultCallback<uv_connect_t, ConnectEvent>);
+        invoke(std::forward<F>(f), get(), std::forward<Args>(args)..., &defaultCallback<ConnectEvent>);
     }
 };
 
@@ -110,7 +110,7 @@ public:
     }
 
     void shutdown(uv_stream_t *handle) {
-        invoke(&uv_shutdown, get(), handle, &defaultCallback<uv_shutdown_t, ShutdownEvent>);
+        invoke(&uv_shutdown, get(), handle, &defaultCallback<ShutdownEvent>);
     }
 };
 
@@ -124,11 +124,11 @@ public:
     }
 
     void write(uv_stream_t *handle, const uv_buf_t bufs[], unsigned int nbufs) {
-        invoke(&uv_write, get(), handle, bufs, nbufs, &defaultCallback<uv_write_t, WriteEvent>);
+        invoke(&uv_write, get(), handle, bufs, nbufs, &defaultCallback<WriteEvent>);
     }
 
     void write(uv_stream_t *handle, const uv_buf_t bufs[], unsigned int nbufs, uv_stream_t *send) {
-        invoke(&uv_write2, get(), handle, bufs, nbufs, send, &defaultCallback<uv_write_t, WriteEvent>);
+        invoke(&uv_write2, get(), handle, bufs, nbufs, send, &defaultCallback<WriteEvent>);
     }
 };
 

--- a/src/uvw/stream.hpp
+++ b/src/uvw/stream.hpp
@@ -243,7 +243,7 @@ public:
      * An EndEvent event will be emitted when there is no more data to read.
      */
     void read() {
-        this->invoke(&uv_read_start, this->template get<uv_stream_t>(), &allocCallback, &readCallback);
+        this->invoke(&uv_read_start, this->template get<uv_stream_t>(), &this->allocCallback, &readCallback);
     }
 
     /**

--- a/src/uvw/stream.hpp
+++ b/src/uvw/stream.hpp
@@ -96,7 +96,7 @@ public:
 
     template<typename F, typename... Args>
     void connect(F &&f, Args... args) {
-        invoke(std::forward<F>(f), get<uv_connect_t>(), std::forward<Args>(args)..., &defaultCallback<uv_connect_t, ConnectEvent>);
+        invoke(std::forward<F>(f), get(), std::forward<Args>(args)..., &defaultCallback<uv_connect_t, ConnectEvent>);
     }
 };
 
@@ -110,7 +110,7 @@ public:
     }
 
     void shutdown(uv_stream_t *handle) {
-        invoke(&uv_shutdown, get<uv_shutdown_t>(), handle, &defaultCallback<uv_shutdown_t, ShutdownEvent>);
+        invoke(&uv_shutdown, get(), handle, &defaultCallback<uv_shutdown_t, ShutdownEvent>);
     }
 };
 
@@ -124,11 +124,11 @@ public:
     }
 
     void write(uv_stream_t *handle, const uv_buf_t bufs[], unsigned int nbufs) {
-        invoke(&uv_write, get<uv_write_t>(), handle, bufs, nbufs, &defaultCallback<uv_write_t, WriteEvent>);
+        invoke(&uv_write, get(), handle, bufs, nbufs, &defaultCallback<uv_write_t, WriteEvent>);
     }
 
     void write(uv_stream_t *handle, const uv_buf_t bufs[], unsigned int nbufs, uv_stream_t *send) {
-        invoke(&uv_write2, get<uv_write_t>(), handle, bufs, nbufs, send, &defaultCallback<uv_write_t, WriteEvent>);
+        invoke(&uv_write2, get(), handle, bufs, nbufs, send, &defaultCallback<uv_write_t, WriteEvent>);
     }
 };
 
@@ -243,7 +243,7 @@ public:
      * An EndEvent event will be emitted when there is no more data to read.
      */
     void read() {
-        this->invoke(&uv_read_start, this->template get<uv_stream_t>(), &this->allocCallback, &readCallback);
+        this->invoke(&uv_read_start, this->template get<uv_stream_t>(), &allocCallback, &readCallback);
     }
 
     /**

--- a/src/uvw/tcp.hpp
+++ b/src/uvw/tcp.hpp
@@ -73,8 +73,8 @@ public:
      */
     bool init() {
         return (tag == FLAGS)
-                ? initialize<uv_tcp_t>(&uv_tcp_init_ex, flags)
-                : initialize<uv_tcp_t>(&uv_tcp_init);
+                ? initialize(&uv_tcp_init_ex, flags)
+                : initialize(&uv_tcp_init);
     }
 
     /**

--- a/src/uvw/tcp.hpp
+++ b/src/uvw/tcp.hpp
@@ -86,7 +86,7 @@ public:
      * @param sock A valid socket handle (either a file descriptor or a SOCKET).
      */
     void open(OSSocketHandle sock) {
-        invoke(&uv_tcp_open, get<uv_tcp_t>(), sock);
+        invoke(&uv_tcp_open, get(), sock);
     }
 
     /**
@@ -95,7 +95,7 @@ public:
      * @return True in case of success, false otherwise.
      */
     bool noDelay(bool value = false) {
-        return (0 == uv_tcp_nodelay(get<uv_tcp_t>(), value));
+        return (0 == uv_tcp_nodelay(get(), value));
     }
 
     /**
@@ -105,7 +105,7 @@ public:
      * @return True in case of success, false otherwise.
      */
     bool keepAlive(bool enable = false, Time time = Time{0}) {
-        return (0 == uv_tcp_keepalive(get<uv_tcp_t>(), enable, time.count()));
+        return (0 == uv_tcp_keepalive(get(), enable, time.count()));
     }
 
     /**
@@ -123,7 +123,7 @@ public:
      * @return True in case of success, false otherwise.
      */
     bool simultaneousAccepts(bool enable = true) {
-        return (0 == uv_tcp_simultaneous_accepts(get<uv_tcp_t>(), enable));
+        return (0 == uv_tcp_simultaneous_accepts(get(), enable));
     }
 
     /**
@@ -147,7 +147,7 @@ public:
     void bind(std::string ip, unsigned int port, Flags<Bind> flags = Flags<Bind>{}) {
         typename details::IpTraits<I>::Type addr;
         details::IpTraits<I>::addrFunc(ip.data(), port, &addr);
-        invoke(&uv_tcp_bind, get<uv_tcp_t>(), reinterpret_cast<const sockaddr *>(&addr), flags);
+        invoke(&uv_tcp_bind, get(), reinterpret_cast<const sockaddr *>(&addr), flags);
     }
 
     /**
@@ -177,7 +177,7 @@ public:
      */
     template<typename I = IPv4>
     Addr sock() const noexcept {
-        return details::address<I>(&uv_tcp_getsockname, get<uv_tcp_t>());
+        return details::address<I>(&uv_tcp_getsockname, get());
     }
 
     /**
@@ -186,7 +186,7 @@ public:
      */
     template<typename I = IPv4>
     Addr peer() const noexcept {
-        return details::address<I>(&uv_tcp_getpeername, get<uv_tcp_t>());
+        return details::address<I>(&uv_tcp_getpeername, get());
     }
 
     /**
@@ -211,7 +211,7 @@ public:
         auto connect = loop().resource<details::ConnectReq>();
         connect->once<ErrorEvent>(listener);
         connect->once<ConnectEvent>(listener);
-        connect->connect(&uv_tcp_connect, get<uv_tcp_t>(), reinterpret_cast<const sockaddr *>(&addr));
+        connect->connect(&uv_tcp_connect, get(), reinterpret_cast<const sockaddr *>(&addr));
     }
 
     /**

--- a/src/uvw/timer.hpp
+++ b/src/uvw/timer.hpp
@@ -51,7 +51,7 @@ public:
      * @return True in case of success, false otherwise.
      */
     bool init() {
-        return initialize<uv_timer_t>(&uv_timer_init);
+        return initialize(&uv_timer_init);
     }
 
     /**

--- a/src/uvw/timer.hpp
+++ b/src/uvw/timer.hpp
@@ -65,14 +65,14 @@ public:
      * @param repeat Milliseconds between successive events.
      */
     void start(Time timeout, Time repeat) {
-        invoke(&uv_timer_start, get<uv_timer_t>(), &startCallback, timeout.count(), repeat.count());
+        invoke(&uv_timer_start, get(), &startCallback, timeout.count(), repeat.count());
     }
 
     /**
      * @brief Stops the handle.
      */
     void stop() {
-        invoke(&uv_timer_stop, get<uv_timer_t>());
+        invoke(&uv_timer_stop, get());
     }
 
     /**
@@ -83,7 +83,7 @@ public:
      * If the timer has never been started before it emits an ErrorEvent event.
      */
     void again() {
-        invoke(&uv_timer_again, get<uv_timer_t>());
+        invoke(&uv_timer_again, get());
     }
 
     /**
@@ -104,7 +104,7 @@ public:
      * @param repeat Repeat interval in milliseconds.
      */
     void repeat(Time repeat) {
-        uv_timer_set_repeat(get<uv_timer_t>(), repeat.count());
+        uv_timer_set_repeat(get(), repeat.count());
     }
 
     /**
@@ -112,7 +112,7 @@ public:
      * @return Timer repeat value in milliseconds.
      */
     Time repeat() {
-        return Time{uv_timer_get_repeat(get<uv_timer_t>())};
+        return Time{uv_timer_get_repeat(get())};
     }
 };
 

--- a/src/uvw/tty.hpp
+++ b/src/uvw/tty.hpp
@@ -101,7 +101,7 @@ public:
      * @return True in case of success, false otherwise.
      */
     bool mode(Mode m) {
-        return (0 == uv_tty_set_mode(get<uv_tty_t>(), static_cast<std::underlying_type_t<Mode>>(m)));
+        return (0 == uv_tty_set_mode(get(), static_cast<std::underlying_type_t<Mode>>(m)));
     }
 
     /**
@@ -119,7 +119,7 @@ public:
     WinSize getWinSize() {
         WinSize size;
 
-        if(0 != uv_tty_get_winsize(get<uv_tty_t>(), &size.width, &size.height)) {
+        if(0 != uv_tty_get_winsize(get(), &size.width, &size.height)) {
             size.width = -1;
             size.height = -1;
         }

--- a/src/uvw/tty.hpp
+++ b/src/uvw/tty.hpp
@@ -81,7 +81,7 @@ public:
      * @return True in case of success, false otherwise.
      */
     bool init() {
-        return initialize<uv_tty_t>(&uv_tty_init, fd, rw);
+        return initialize(&uv_tty_init, fd, rw);
     }
 
     /**

--- a/src/uvw/udp.hpp
+++ b/src/uvw/udp.hpp
@@ -89,7 +89,7 @@ public:
     }
 
     void send(uv_udp_t *handle, const uv_buf_t bufs[], unsigned int nbufs, const struct sockaddr* addr) {
-        invoke(&uv_udp_send, get<uv_udp_send_t>(), handle, bufs, nbufs, addr, &defaultCallback<uv_udp_send_t, SendEvent>);
+        invoke(&uv_udp_send, get(), handle, bufs, nbufs, addr, &defaultCallback<uv_udp_send_t, SendEvent>);
     }
 };
 
@@ -182,7 +182,7 @@ public:
      * @param sock A valid socket handle (either a file descriptor or a SOCKET).
      */
     void open(OSSocketHandle sock) {
-        invoke(&uv_udp_open, get<uv_udp_t>(), sock);
+        invoke(&uv_udp_open, get(), sock);
     }
 
     /**
@@ -205,7 +205,7 @@ public:
     void bind(std::string ip, unsigned int port, Flags<Bind> flags = Flags<Bind>{}) {
         typename details::IpTraits<I>::Type addr;
         details::IpTraits<I>::addrFunc(ip.data(), port, &addr);
-        invoke(&uv_udp_bind, get<uv_udp_t>(), reinterpret_cast<const sockaddr *>(&addr), flags);
+        invoke(&uv_udp_bind, get(), reinterpret_cast<const sockaddr *>(&addr), flags);
     }
 
     /**
@@ -234,7 +234,7 @@ public:
      */
     template<typename I = IPv4>
     Addr sock() const noexcept {
-        return details::address<I>(&uv_udp_getsockname, get<uv_udp_t>());
+        return details::address<I>(&uv_udp_getsockname, get());
     }
 
     /**
@@ -252,7 +252,7 @@ public:
      */
     template<typename I = IPv4>
     bool multicastMembership(std::string multicast, std::string iface, Membership membership) {
-        return (0 == uv_udp_set_membership(get<uv_udp_t>(), multicast.data(), iface.data(), static_cast<uv_membership>(membership)));
+        return (0 == uv_udp_set_membership(get(), multicast.data(), iface.data(), static_cast<uv_membership>(membership)));
     }
 
     /**
@@ -264,7 +264,7 @@ public:
      * @return True in case of success, false otherwise.
      */
     bool multicastLoop(bool enable = true) {
-        return (0 == uv_udp_set_multicast_loop(get<uv_udp_t>(), enable));
+        return (0 == uv_udp_set_multicast_loop(get(), enable));
     }
 
     /**
@@ -273,7 +273,7 @@ public:
      * @return True in case of success, false otherwise.
      */
     bool multicastTtl(int val) {
-        return (0 == uv_udp_set_multicast_ttl(get<uv_udp_t>(), val > 255 ? 255 : val));
+        return (0 == uv_udp_set_multicast_ttl(get(), val > 255 ? 255 : val));
     }
 
     /**
@@ -283,7 +283,7 @@ public:
      */
     template<typename I = IPv4>
     bool multicastInterface(std::string iface) {
-        return (0 == uv_udp_set_multicast_interface(get<uv_udp_t>(), iface.data()));
+        return (0 == uv_udp_set_multicast_interface(get(), iface.data()));
     }
 
     /**
@@ -292,7 +292,7 @@ public:
      * @return True in case of success, false otherwise.
      */
     bool broadcast(bool enable = false) {
-        return (0 == uv_udp_set_broadcast(get<uv_udp_t>(), enable));
+        return (0 == uv_udp_set_broadcast(get(), enable));
     }
 
     /**
@@ -301,7 +301,7 @@ public:
      * @return True in case of success, false otherwise.
      */
     bool ttl(int val) {
-        return (0 == uv_udp_set_ttl(get<uv_udp_t>(), val > 255 ? 255 : val));
+        return (0 == uv_udp_set_ttl(get(), val > 255 ? 255 : val));
     }
 
     /**
@@ -333,7 +333,7 @@ public:
         auto send = loop().resource<details::Send>();
         send->once<ErrorEvent>(listener);
         send->once<SendEvent>(listener);
-        send->send(get<uv_udp_t>(), bufs, 1, reinterpret_cast<const sockaddr *>(&addr));
+        send->send(get(), bufs, 1, reinterpret_cast<const sockaddr *>(&addr));
     }
 
     /**
@@ -354,7 +354,7 @@ public:
         details::IpTraits<I>::addrFunc(ip.data(), port, &addr);
 
         uv_buf_t bufs[] = { uv_buf_init(data.get(), len) };
-        auto bw = uv_udp_try_send(get<uv_udp_t>(), bufs, 1, reinterpret_cast<const sockaddr *>(&addr));
+        auto bw = uv_udp_try_send(get(), bufs, 1, reinterpret_cast<const sockaddr *>(&addr));
 
         if(bw < 0) {
             publish(ErrorEvent{bw});
@@ -376,14 +376,14 @@ public:
      */
     template<typename I = IPv4>
     void recv() {
-        invoke(&uv_udp_recv_start, get<uv_udp_t>(), &allocCallback, &recvCallback<I>);
+        invoke(&uv_udp_recv_start, get(), &allocCallback, &recvCallback<I>);
     }
 
     /**
      * @brief Stops listening for incoming datagrams.
      */
     void stop() {
-        invoke(&uv_udp_recv_stop, get<uv_udp_t>());
+        invoke(&uv_udp_recv_stop, get());
     }
 
 private:

--- a/src/uvw/udp.hpp
+++ b/src/uvw/udp.hpp
@@ -89,7 +89,7 @@ public:
     }
 
     void send(uv_udp_t *handle, const uv_buf_t bufs[], unsigned int nbufs, const struct sockaddr* addr) {
-        invoke(&uv_udp_send, get(), handle, bufs, nbufs, addr, &defaultCallback<uv_udp_send_t, SendEvent>);
+        invoke(&uv_udp_send, get(), handle, bufs, nbufs, addr, &defaultCallback<SendEvent>);
     }
 };
 

--- a/src/uvw/udp.hpp
+++ b/src/uvw/udp.hpp
@@ -165,8 +165,8 @@ public:
      */
     bool init() {
         return (tag == FLAGS)
-                ? initialize<uv_udp_t>(&uv_udp_init_ex, flags)
-                : initialize<uv_udp_t>(&uv_udp_init);
+                ? initialize(&uv_udp_init_ex, flags)
+                : initialize(&uv_udp_init);
     }
 
     /**

--- a/src/uvw/work.hpp
+++ b/src/uvw/work.hpp
@@ -64,7 +64,7 @@ public:
      * This request can be cancelled with `cancel()`.
      */
     void queue() {
-        invoke(&uv_queue_work, parent(), get(), &workCallback, &defaultCallback<uv_work_t, WorkEvent>);
+        invoke(&uv_queue_work, parent(), get(), &workCallback, &defaultCallback<WorkEvent>);
     }
 
 private:

--- a/src/uvw/work.hpp
+++ b/src/uvw/work.hpp
@@ -64,7 +64,7 @@ public:
      * This request can be cancelled with `cancel()`.
      */
     void queue() {
-        invoke(&uv_queue_work, parent(), get<uv_work_t>(), &workCallback, &defaultCallback<uv_work_t, WorkEvent>);
+        invoke(&uv_queue_work, parent(), get(), &workCallback, &defaultCallback<uv_work_t, WorkEvent>);
     }
 
 private:


### PR DESCRIPTION
This is an attempt to reduce the number of times `uv_*_t` identifiers are mentioned in uvw code.
Since they appear in most declarations (template parameter of the class/member function), the identifier itself can be removed in favor of a template parameter, which can further be left for the compiler to deduce.

This also reduces the repetition of `uv_*_t` in the same class. Using the declaration of the class template parameters, members can directly `get` the same inner uv type without using the name and specifying an independent template parameter (see `Resource::get`, `Handle::initialize` and `Request::defaultCallback`).

One seemingly unrelated change is in `lib.hpp` where a locally defined details::IsFunc is removed in favor of [the standard `std::is_function`](http://en.cppreference.com/w/cpp/types/is_function). This allows `F` to take more lenient forms like variadic functions, etc.