### PR TITLE
Code coverage using coveralls.io

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ matrix:
     before_script:
     - pip install --user cpp-coveralls
     after_success:
-    - coveralls --gcov gcov-6 --gcov-options '\-lp' --exclude deps
+    - coveralls --gcov gcov-6 --gcov-options '\-lp' --root ${TRAVIS_BUILD_DIR} --build-root ${TRAVIS_BUILD_DIR}/build --exclude deps --include src
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,42 +1,53 @@
-os:
-- linux
+language: cpp
 
 matrix:
   include:
+  - os: linux
+    compiler: gcc
+    addons:
+      apt:
+        sources: ['ubuntu-toolchain-r-test']
+        packages: ['g++-5']
+    env: COMPILER=g++-5
+  - os: linux
+    compiler: gcc
+    addons:
+      apt:
+        sources: ['ubuntu-toolchain-r-test']
+        packages: ['g++-6']
+    env: COMPILER=g++-6
+  - os: linux
+    compiler: clang
+    addons:
+      apt:
+        sources: ['ubuntu-toolchain-r-test', 'llvm-toolchain-precise-3.8']
+        packages: ['clang-3.8']
+    env: COMPILER=clang++-3.8
   - os: osx
     osx_image: xcode7.3
-
-addons:
-  apt:
-    sources:
-    - ubuntu-toolchain-r-test
-    - llvm-toolchain-precise-3.8
-    packages:
-    - gcc-5
-    - g++-5
-    - clang-3.8
-
-language: cpp
-compiler:
-- gcc
-- clang
+    compiler: clang
+    env: COMPILER=clang++
+  - os: osx
+    osx_image: xcode8
+    compiler: clang
+    env: COMPILER=clang++
 
 notifications:
   email:
     on_success: never
     on_failure: always
 
-before_install: ./travis.sh
-
 install:
-- if [ "$CXX" = "g++" ] && [ "$TRAVIS_OS_NAME" = "linux" ]; then export CXX="g++-5" CC="gcc-5"; fi
-- if [ "$CXX" = "clang++" ] && [ "$TRAVIS_OS_NAME" = "linux" ]; then export CXX="clang++-3.8" CC="clang-3.8"; fi
 - echo ${PATH}
+- ./travis.sh
+- cmake --version
+- export CXX=${COMPILER}
 - echo ${CXX}
 - ${CXX} --version
 - ${CXX} -v
-- cmake --version
+- ./deps.sh
 
-before_script: ./deps.sh
-
-script: mkdir -p build && cd build && cmake .. && make && make test
+script:
+- mkdir -p build && cd build
+- cmake .. && make -j4
+- CTEST_OUTPUT_ON_FAILURE=1 make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,20 @@ matrix:
     compiler: clang
     env: COMPILER=clang++
 
+  - os: linux
+    compiler: gcc
+    addons:
+      apt:
+        sources: ['ubuntu-toolchain-r-test']
+        packages: ['g++-6']
+    env:
+    - COMPILER=g++-6
+    - CXXFLAGS="-O0 --coverage"
+    before_script:
+    - pip install --user cpp-coveralls
+    after_success:
+    - coveralls --gcov gcov-6 --gcov-options '\-lp' --exclude deps
+
 notifications:
   email:
     on_success: never


### PR DESCRIPTION
Added the code coverage reporting and integrated with [coveralls.io](https://coveralls.io/) for visualizing and tracking the coverage numbers. [Here](https://coveralls.io/builds/8234660) is a sample report from the test build.<br />* Reorganized the Travis configuration to streamline adding new builds/tool-chains later on.<br />* Added the new jobs in travis:<br /> - `g++-6` for Linux<br /> - `xcode8` for macOS<br /><br />Left the badge for `README.md` to be added later.