### PR TITLE
Replaced `for` loop as mentioned in comment

### DIFF
--- a/src/uvw/stream.hpp
+++ b/src/uvw/stream.hpp
@@ -118,9 +118,7 @@ class WriteReq final: public Request<WriteReq, uv_write_t> {
           bufs{new uv_buf_t[N], &deleter<N>},
           nbufs{N}
     {
-        for(std::size_t i = 0; i < N; ++i) {
-            bufs[i] = arr[i];
-        }
+        std::copy_n(std::begin(arr), N, bufs.get());
     }
 
 public:

--- a/src/uvw/udp.hpp
+++ b/src/uvw/udp.hpp
@@ -3,6 +3,7 @@
 
 #include <type_traits>
 #include <algorithm>
+#include <iterator>
 #include <utility>
 #include <cstddef>
 #include <memory>
@@ -72,9 +73,7 @@ class SendReq final: public Request<SendReq, uv_udp_send_t> {
           bufs{new uv_buf_t[N], &deleter<N>},
           nbufs{N}
     {
-        for(std::size_t i = 0; i < N; ++i) {
-            bufs[i] = arr[i];
-        }
+        std::copy_n(std::begin(arr), N, bufs.get());
     }
 
 public:

--- a/test/uvw/loop.cpp
+++ b/test/uvw/loop.cpp
@@ -2,7 +2,7 @@
 #include <uvw.hpp>
 
 
-TEST(Loop, PartiallyDone) {
+TEST(Loop, DefaultLoop) {
     auto def = uvw::Loop::getDefault();
 
     ASSERT_TRUE(static_cast<bool>(def));
@@ -10,6 +10,13 @@ TEST(Loop, PartiallyDone) {
     ASSERT_NO_THROW(def->stop());
 
     def->walk([](uvw::BaseHandle &) { FAIL(); });
+
+    auto def2 = uvw::Loop::getDefault();
+    ASSERT_EQ(def, def2);
+}
+
+
+TEST(Loop, PartiallyDone) {
 
     auto loop = uvw::Loop::create();
     auto handle = loop->resource<uvw::PrepareHandle>();


### PR DESCRIPTION
Also contains a commit to get the code coverage back to the old value: added a statement to `ASSERT` the pointer to default loop returned is the same on the second call to `Loop::getDefault`.