### PR TITLE
Cleanup further

### DIFF
--- a/src/uvw/dns.hpp
+++ b/src/uvw/dns.hpp
@@ -72,7 +72,7 @@ struct NameInfoEvent: Event<NameInfoEvent> {
  */
 class GetAddrInfoReq final: public Request<GetAddrInfoReq, uv_getaddrinfo_t> {
     static void getAddrInfoCallback(uv_getaddrinfo_t *req, int status, addrinfo *res) {
-        auto ptr = reserve(reinterpret_cast<uv_req_t*>(req));
+        auto ptr = reserve(req);
 
         if(status) {
             ptr->publish(ErrorEvent{status});
@@ -199,7 +199,7 @@ public:
  */
 class GetNameInfoReq final: public Request<GetNameInfoReq, uv_getnameinfo_t> {
     static void getNameInfoCallback(uv_getnameinfo_t *req, int status, const char *hostname, const char *service) {
-        auto ptr = reserve(reinterpret_cast<uv_req_t*>(req));
+        auto ptr = reserve(req);
         if(status) { ptr->publish(ErrorEvent{status}); }
         else { ptr->publish(NameInfoEvent{hostname, service}); }
     }

--- a/src/uvw/fs.hpp
+++ b/src/uvw/fs.hpp
@@ -282,21 +282,21 @@ class FsRequest: public Request<T, uv_fs_t> {
 protected:
     template<details::UVFsType e>
     static void fsGenericCallback(uv_fs_t *req) {
-        auto ptr = Request<T, uv_fs_t>::reserve(reinterpret_cast<uv_req_t*>(req));
+        auto ptr = Request<T, uv_fs_t>::reserve(req);
         if(req->result < 0) { ptr->publish(ErrorEvent{req->result}); }
         else { ptr->publish(FsEvent<e>{req->path}); }
     }
 
     template<details::UVFsType e>
     static void fsResultCallback(uv_fs_t *req) {
-        auto ptr = Request<T, uv_fs_t>::reserve(reinterpret_cast<uv_req_t*>(req));
+        auto ptr = Request<T, uv_fs_t>::reserve(req);
         if(req->result < 0) { ptr->publish(ErrorEvent{req->result}); }
         else { ptr->publish(FsEvent<e>{req->path, req->result}); }
     }
 
     template<details::UVFsType e>
     static void fsStatCallback(uv_fs_t *req) {
-        auto ptr = Request<T, uv_fs_t>::reserve(reinterpret_cast<uv_req_t*>(req));
+        auto ptr = Request<T, uv_fs_t>::reserve(req);
         if(req->result < 0) { ptr->publish(ErrorEvent{req->result}); }
         else { ptr->publish(FsEvent<e>{req->path, req->statbuf}); }
     }
@@ -337,7 +337,7 @@ class FileReq final: public FsRequest<FileReq> {
     static constexpr uv_file BAD_FD = -1;
 
     static void fsOpenCallback(uv_fs_t *req) {
-        auto ptr = reserve(reinterpret_cast<uv_req_t*>(req));
+        auto ptr = reserve(req);
 
         if(req->result < 0) {
             ptr->publish(ErrorEvent{req->result});
@@ -348,7 +348,7 @@ class FileReq final: public FsRequest<FileReq> {
     }
 
     static void fsCloseCallback(uv_fs_t *req) {
-        auto ptr = reserve(reinterpret_cast<uv_req_t*>(req));
+        auto ptr = reserve(req);
 
         if(req->result < 0) {
             ptr->publish(ErrorEvent{req->result});
@@ -359,7 +359,7 @@ class FileReq final: public FsRequest<FileReq> {
     }
 
     static void fsReadCallback(uv_fs_t *req) {
-        auto ptr = reserve(reinterpret_cast<uv_req_t*>(req));
+        auto ptr = reserve(req);
         if(req->result < 0) { ptr->publish(ErrorEvent{req->result}); }
         else { ptr->publish(FsEvent<Type::READ>{req->path, std::move(ptr->data), req->result}); }
     }
@@ -725,7 +725,7 @@ private:
  */
 class FsReq final: public FsRequest<FsReq> {
     static void fsReadlinkCallback(uv_fs_t *req) {
-        auto ptr = reserve(reinterpret_cast<uv_req_t*>(req));
+        auto ptr = reserve(req);
         if(req->result < 0) { ptr->publish(ErrorEvent{req->result}); }
         else { ptr->publish(FsEvent<Type::READLINK>{req->path, static_cast<char *>(req->ptr), req->result}); }
     }

--- a/src/uvw/loop.hpp
+++ b/src/uvw/loop.hpp
@@ -1,8 +1,10 @@
 #pragma once
 
+
 #ifdef _WIN32
 #include <ciso646>
 #endif
+
 #include <new>
 #include <memory>
 #include <utility>

--- a/src/uvw/loop.hpp
+++ b/src/uvw/loop.hpp
@@ -1,5 +1,8 @@
 #pragma once
 
+#ifdef _WIN32
+#include <ciso646>
+#endif
 #include <new>
 #include <memory>
 #include <utility>
@@ -7,10 +10,6 @@
 #include <chrono>
 #include <uv.h>
 #include "emitter.hpp"
-
-#ifdef _WIN32
-#include <ciso646>
-#endif
 
 
 namespace uvw {

--- a/src/uvw/request.hpp
+++ b/src/uvw/request.hpp
@@ -16,7 +16,7 @@ class Request: public Resource<T, U> {
 protected:
     using Resource<T, U>::Resource;
 
-    static auto reserve(uv_req_t *req) {
+    static auto reserve(U *req) {
         auto ptr = static_cast<T*>(req->data)->shared_from_this();
         ptr->reset();
         return ptr;
@@ -24,7 +24,7 @@ protected:
 
     template<typename E>
     static void defaultCallback(U *req, int status) {
-        auto ptr = reserve(reinterpret_cast<uv_req_t*>(req));
+        auto ptr = reserve(req);
         if(status) { ptr->publish(ErrorEvent{status}); }
         else { ptr->publish(E{}); }
     }


### PR DESCRIPTION
A continuation of PR #61.

The changes reduce the number of times `uv_*_t` identifiers occur in `uvw` code further. This focuses on the Request hierarchy (the Handle hierarchy was covered in the previous PR).

Also, made the change agreed upon in [this comment](https://github.com/skypjack/uvw/commit/2838f6e239cbefa68e900e55760e20660f5fa73e#commitcomment-19736512).