### PR TITLE
made DataEvent::data unique_ptr non-const

### DIFF
--- a/src/uvw/stream.hpp
+++ b/src/uvw/stream.hpp
@@ -143,7 +143,7 @@ class StreamHandle: public Handle<T, U> {
     static void readCallback(uv_stream_t *handle, ssize_t nread, const uv_buf_t *buf) {
         T &ref = *(static_cast<T*>(handle->data));
         // data will be destroyed no matter of what the value of nread is
-        std::unique_ptr<const char[]> data{buf->base};
+        std::unique_ptr<char[]> data{buf->base};
 
         if(nread == UV_EOF) {
             // end of stream

--- a/src/uvw/stream.hpp
+++ b/src/uvw/stream.hpp
@@ -62,11 +62,11 @@ struct WriteEvent: Event<WriteEvent> { };
  * It will be emitted by StreamHandle according with its functionalities.
  */
 struct DataEvent: Event<DataEvent> {
-    explicit DataEvent(std::unique_ptr<const char[]> data, ssize_t length) noexcept
+    explicit DataEvent(std::unique_ptr<char[]> data, ssize_t length) noexcept
         : data{std::move(data)}, length(length)
     { }
 
-    std::unique_ptr<const char[]> data; /*!< A bunch of data read on the stream. */
+    std::unique_ptr<char[]> data; /*!< A bunch of data read on the stream. */
     std::size_t length; /*!< The amount of data read on the stream. */
 };
 


### PR DESCRIPTION
There is no reason to force client code to get read data as an `std::unique_ptr<const char[]>`, and I would change the type of `DataEvent::data` to `std::unique_ptr<char[]>` for two reasons:

- I think it's up to the user whether he wants those data to be modifiable or not
- this way, I could use data received in a `DataEvent` as an argument for `StreamHandle::write()`; on the other hand, if `DataEvent::data` is a _pointer to const_, if I want to write those data through a `StreamHandle` I'm forced to perform an avoidable copy

As a side note: it would be great if the `StreamHandle::write()` function would accept _pointer to const_ as a data argument, but I've not been able to find any guarantee in _libuv_ documentation that those buffer will not be modified by the write (as it should be), so I'm not sure we can `const_cast` our const buffers before they are passed to the `uv_write()` function.