### PR TITLE
replaced ssize_t with std::size_t in ctors

### DIFF
--- a/src/uvw/fs.hpp
+++ b/src/uvw/fs.hpp
@@ -128,8 +128,8 @@ template<>
 struct FsEvent<details::UVFsType::READ>
         : Event<FsEvent<details::UVFsType::READ>>
 {
-    FsEvent(const char *path, std::unique_ptr<const char[]> data, ssize_t size) noexcept
-        : path{path}, data{std::move(data)}, size(size)
+    FsEvent(const char *path, std::unique_ptr<const char[]> data, std::size_t size) noexcept
+        : path{path}, data{std::move(data)}, size{size}
     { }
 
     const char * path; /*!< The path affecting the request. */
@@ -148,8 +148,8 @@ template<>
 struct FsEvent<details::UVFsType::WRITE>
         : Event<FsEvent<details::UVFsType::WRITE>>
 {
-    FsEvent(const char *path, ssize_t size) noexcept
-        : path{path}, size(size)
+    FsEvent(const char *path, std::size_t size) noexcept
+        : path{path}, size{size}
     { }
 
     const char * path; /*!< The path affecting the request. */
@@ -167,8 +167,8 @@ template<>
 struct FsEvent<details::UVFsType::SENDFILE>
         : Event<FsEvent<details::UVFsType::SENDFILE>>
 {
-    FsEvent(const char *path, ssize_t size) noexcept
-        : path{path}, size(size)
+    FsEvent(const char *path, std::size_t size) noexcept
+        : path{path}, size{size}
     { }
 
     const char * path; /*!< The path affecting the request. */
@@ -243,8 +243,8 @@ template<>
 struct FsEvent<details::UVFsType::SCANDIR>
         : Event<FsEvent<details::UVFsType::SCANDIR>>
 {
-    FsEvent(const char *path, ssize_t size) noexcept
-        : path{path}, size(size)
+    FsEvent(const char *path, std::size_t size) noexcept
+        : path{path}, size{size}
     { }
 
     const char * path; /*!< The path affecting the request. */
@@ -262,8 +262,8 @@ template<>
 struct FsEvent<details::UVFsType::READLINK>
         : Event<FsEvent<details::UVFsType::READLINK>>
 {
-    explicit FsEvent(const char *path, const char *data, ssize_t size) noexcept
-        : path{path}, data{data}, size(size)
+    explicit FsEvent(const char *path, const char *data, std::size_t size) noexcept
+        : path{path}, data{data}, size{size}
     { }
 
     const char * path; /*!< The path affecting the request. */
@@ -291,7 +291,7 @@ protected:
     static void fsResultCallback(uv_fs_t *req) {
         auto ptr = Request<T, uv_fs_t>::reserve(req);
         if(req->result < 0) { ptr->publish(ErrorEvent{req->result}); }
-        else { ptr->publish(FsEvent<e>{req->path, req->result}); }
+        else { ptr->publish(FsEvent<e>{req->path, static_cast<std::size_t>(req->result)}); }
     }
 
     template<details::UVFsType e>
@@ -363,7 +363,7 @@ class FileReq final: public FsRequest<FileReq> {
     static void fsReadCallback(uv_fs_t *req) {
         auto ptr = reserve(req);
         if(req->result < 0) { ptr->publish(ErrorEvent{req->result}); }
-        else { ptr->publish(FsEvent<Type::READ>{req->path, std::move(ptr->data), req->result}); }
+        else { ptr->publish(FsEvent<Type::READ>{req->path, std::move(ptr->data), static_cast<std::size_t>(req->result)}); }
     }
 
 public:
@@ -746,7 +746,7 @@ class FsReq final: public FsRequest<FsReq> {
     static void fsReadlinkCallback(uv_fs_t *req) {
         auto ptr = reserve(req);
         if(req->result < 0) { ptr->publish(ErrorEvent{req->result}); }
-        else { ptr->publish(FsEvent<Type::READLINK>{req->path, static_cast<char *>(req->ptr), req->result}); }
+        else { ptr->publish(FsEvent<Type::READLINK>{req->path, static_cast<char *>(req->ptr), static_cast<std::size_t>(req->result)}); }
     }
 
 public:

--- a/src/uvw/stream.hpp
+++ b/src/uvw/stream.hpp
@@ -62,8 +62,8 @@ struct WriteEvent: Event<WriteEvent> { };
  * It will be emitted by StreamHandle according with its functionalities.
  */
 struct DataEvent: Event<DataEvent> {
-    explicit DataEvent(std::unique_ptr<char[]> data, ssize_t length) noexcept
-        : data{std::move(data)}, length(length)
+    explicit DataEvent(std::unique_ptr<char[]> data, std::size_t length) noexcept
+        : data{std::move(data)}, length{length}
     { }
 
     std::unique_ptr<char[]> data; /*!< A bunch of data read on the stream. */
@@ -141,7 +141,7 @@ class StreamHandle: public Handle<T, U> {
             ref.publish(EndEvent{});
         } else if(nread > 0) {
             // data available
-            ref.publish(DataEvent{std::move(data), nread});
+            ref.publish(DataEvent{std::move(data), static_cast<std::size_t>(nread)});
         } else {
             // transmission error
             ref.publish(ErrorEvent(nread));

--- a/src/uvw/udp.hpp
+++ b/src/uvw/udp.hpp
@@ -32,8 +32,8 @@ struct SendEvent: Event<SendEvent> { };
  * It will be emitted by UDPHandle according with its functionalities.
  */
 struct UDPDataEvent: Event<UDPDataEvent> {
-    explicit UDPDataEvent(Addr sender, std::unique_ptr<const char[]> data, ssize_t length, bool partial) noexcept
-        : data{std::move(data)}, length(length), sender{std::move(sender)}, partial{partial}
+    explicit UDPDataEvent(Addr sender, std::unique_ptr<const char[]> data, std::size_t length, bool partial) noexcept
+        : data{std::move(data)}, length{length}, sender{std::move(sender)}, partial{partial}
     { }
 
     std::unique_ptr<const char[]> data; /*!< A bunch of data read on the stream. */


### PR DESCRIPTION
It does make sense to me that `ssize_t` does not even appear in `uvw` interfaces; this way, ctors can use _uniform initialization_ to initialize `length`'s member variables (thus requiring diagnostic for narrowing conversions, if I'm not wrong), and explicit casts are performed where they belongs to, inside the implementation, where you have just checked that the variable you are casting from `ssize_t` to `std::size_t` is `>=0`.