### PR TITLE
Fix GCC warnings -Wshadow

### DIFF
--- a/src/uvw/dns.hpp
+++ b/src/uvw/dns.hpp
@@ -22,8 +22,8 @@ namespace uvw {
 struct AddrInfoEvent: Event<AddrInfoEvent> {
     using Deleter = void(*)(addrinfo *);
 
-    AddrInfoEvent(std::unique_ptr<addrinfo, Deleter> _data)
-        : data{std::move(_data)}
+    AddrInfoEvent(std::unique_ptr<addrinfo, Deleter> addr)
+        : data{std::move(addr)}
     {}
 
     /**
@@ -42,8 +42,8 @@ struct AddrInfoEvent: Event<AddrInfoEvent> {
  * It will be emitted by GetNameInfoReq according with its functionalities.
  */
 struct NameInfoEvent: Event<NameInfoEvent> {
-    NameInfoEvent(const char *_hostname, const char *_service)
-        : hostname{_hostname}, service{_service}
+    NameInfoEvent(const char *host, const char *serv)
+        : hostname{host}, service{serv}
     {}
 
     /**
@@ -80,7 +80,7 @@ class GetAddrInfoReq final: public Request<GetAddrInfoReq, uv_getaddrinfo_t> {
             ptr->publish(ErrorEvent{status});
         } else {
             auto data = std::unique_ptr<addrinfo, void(*)(addrinfo *)>{
-                res, [](addrinfo *_res){ uv_freeaddrinfo(_res); }};
+                res, [](addrinfo *addr){ uv_freeaddrinfo(addr); }};
 
             ptr->publish(AddrInfoEvent{std::move(data)});
         }
@@ -93,8 +93,8 @@ class GetAddrInfoReq final: public Request<GetAddrInfoReq, uv_getaddrinfo_t> {
     auto getNodeAddrInfoSync(const char *node, const char *service, addrinfo *hints = nullptr) {
         auto req = get();
         auto err = uv_getaddrinfo(parent(), req, nullptr, node, service, hints);
-        auto _ptr = std::unique_ptr<addrinfo, void(*)(addrinfo *)>{req->addrinfo, [](addrinfo *_res){ uv_freeaddrinfo(_res); }};
-        return std::make_pair(!err, std::move(_ptr));
+        auto data = std::unique_ptr<addrinfo, void(*)(addrinfo *)>{req->addrinfo, [](addrinfo *addr){ uv_freeaddrinfo(addr); }};
+        return std::make_pair(!err, std::move(data));
     }
 
 public:

--- a/src/uvw/dns.hpp
+++ b/src/uvw/dns.hpp
@@ -22,8 +22,8 @@ namespace uvw {
 struct AddrInfoEvent: Event<AddrInfoEvent> {
     using Deleter = void(*)(addrinfo *);
 
-    AddrInfoEvent(std::unique_ptr<addrinfo, Deleter> data)
-        : data{std::move(data)}
+    AddrInfoEvent(std::unique_ptr<addrinfo, Deleter> _data)
+        : data{std::move(_data)}
     {}
 
     /**
@@ -42,8 +42,8 @@ struct AddrInfoEvent: Event<AddrInfoEvent> {
  * It will be emitted by GetNameInfoReq according with its functionalities.
  */
 struct NameInfoEvent: Event<NameInfoEvent> {
-    NameInfoEvent(const char *hostname, const char *service)
-        : hostname{hostname}, service{service}
+    NameInfoEvent(const char *_hostname, const char *_service)
+        : hostname{_hostname}, service{_service}
     {}
 
     /**
@@ -80,7 +80,7 @@ class GetAddrInfoReq final: public Request<GetAddrInfoReq, uv_getaddrinfo_t> {
             ptr->publish(ErrorEvent{status});
         } else {
             auto data = std::unique_ptr<addrinfo, void(*)(addrinfo *)>{
-                res, [](addrinfo *res){ uv_freeaddrinfo(res); }};
+                res, [](addrinfo *_res){ uv_freeaddrinfo(_res); }};
 
             ptr->publish(AddrInfoEvent{std::move(data)});
         }
@@ -93,8 +93,8 @@ class GetAddrInfoReq final: public Request<GetAddrInfoReq, uv_getaddrinfo_t> {
     auto getNodeAddrInfoSync(const char *node, const char *service, addrinfo *hints = nullptr) {
         auto req = get();
         auto err = uv_getaddrinfo(parent(), req, nullptr, node, service, hints);
-        auto ptr = std::unique_ptr<addrinfo, void(*)(addrinfo *)>{req->addrinfo, [](addrinfo *res){ uv_freeaddrinfo(res); }};
-        return std::make_pair(!err, std::move(ptr));
+        auto _ptr = std::unique_ptr<addrinfo, void(*)(addrinfo *)>{req->addrinfo, [](addrinfo *_res){ uv_freeaddrinfo(_res); }};
+        return std::make_pair(!err, std::move(_ptr));
     }
 
 public:

--- a/src/uvw/emitter.hpp
+++ b/src/uvw/emitter.hpp
@@ -212,7 +212,7 @@ public:
      */
     void clear() noexcept {
         std::for_each(handlers.begin(), handlers.end(),
-                      [](auto &&handler){ if(handler) { handler->clear(); } });
+                      [](auto &&_handler){ if(_handler) { _handler->clear(); } });
     }
 
     /**
@@ -236,7 +236,7 @@ public:
      */
     bool empty() const noexcept {
         return std::all_of(handlers.cbegin(), handlers.cend(),
-                           [](auto &&handler){ return !handler || handler->empty(); });
+                           [](auto &&_handler){ return !_handler || _handler->empty(); });
     }
 
 private:

--- a/src/uvw/emitter.hpp
+++ b/src/uvw/emitter.hpp
@@ -212,7 +212,7 @@ public:
      */
     void clear() noexcept {
         std::for_each(handlers.begin(), handlers.end(),
-                      [](auto &&_handler){ if(_handler) { _handler->clear(); } });
+                      [](auto &&hdlr){ if(hdlr) { hdlr->clear(); } });
     }
 
     /**
@@ -236,7 +236,7 @@ public:
      */
     bool empty() const noexcept {
         return std::all_of(handlers.cbegin(), handlers.cend(),
-                           [](auto &&_handler){ return !_handler || _handler->empty(); });
+                           [](auto &&hdlr){ return !hdlr || hdlr->empty(); });
     }
 
 private:

--- a/src/uvw/fs.hpp
+++ b/src/uvw/fs.hpp
@@ -186,8 +186,8 @@ template<>
 struct FsEvent<details::UVFsType::STAT>
         : Event<FsEvent<details::UVFsType::STAT>>
 {
-    FsEvent(const char *pathname, Stat _stat) noexcept
-        : path{pathname}, stat{std::move(_stat)}
+    FsEvent(const char *pathname, Stat curr) noexcept
+        : path{pathname}, stat{std::move(curr)}
     {}
 
     const char * path; /*!< The path affecting the request. */
@@ -205,8 +205,8 @@ template<>
 struct FsEvent<details::UVFsType::FSTAT>
         : Event<FsEvent<details::UVFsType::FSTAT>>
 {
-    FsEvent(const char *pathname, Stat _stat) noexcept
-        : path{pathname}, stat{std::move(_stat)}
+    FsEvent(const char *pathname, Stat curr) noexcept
+        : path{pathname}, stat{std::move(curr)}
     {}
 
     const char * path; /*!< The path affecting the request. */
@@ -224,8 +224,8 @@ template<>
 struct FsEvent<details::UVFsType::LSTAT>
         : Event<FsEvent<details::UVFsType::LSTAT>>
 {
-    FsEvent(const char *pathname, Stat _stat) noexcept
-        : path{pathname}, stat{std::move(_stat)}
+    FsEvent(const char *pathname, Stat curr) noexcept
+        : path{pathname}, stat{std::move(curr)}
     {}
 
     const char * path; /*!< The path affecting the request. */

--- a/src/uvw/fs.hpp
+++ b/src/uvw/fs.hpp
@@ -128,8 +128,8 @@ template<>
 struct FsEvent<details::UVFsType::READ>
         : Event<FsEvent<details::UVFsType::READ>>
 {
-    FsEvent(const char *_path, std::unique_ptr<const char[]> _data, std::size_t _size) noexcept
-        : path{_path}, data{std::move(_data)}, size{_size}
+    FsEvent(const char *_path, std::unique_ptr<const char[]> _data, std::size_t sz) noexcept
+        : path{_path}, data{std::move(_data)}, size{sz}
     {}
 
     const char * path; /*!< The path affecting the request. */
@@ -148,8 +148,8 @@ template<>
 struct FsEvent<details::UVFsType::WRITE>
         : Event<FsEvent<details::UVFsType::WRITE>>
 {
-    FsEvent(const char *_path, std::size_t _size) noexcept
-        : path{_path}, size{_size}
+    FsEvent(const char *_path, std::size_t sz) noexcept
+        : path{_path}, size{sz}
     {}
 
     const char * path; /*!< The path affecting the request. */
@@ -167,8 +167,8 @@ template<>
 struct FsEvent<details::UVFsType::SENDFILE>
         : Event<FsEvent<details::UVFsType::SENDFILE>>
 {
-    FsEvent(const char *_path, std::size_t _size) noexcept
-        : path{_path}, size{_size}
+    FsEvent(const char *_path, std::size_t sz) noexcept
+        : path{_path}, size{sz}
     {}
 
     const char * path; /*!< The path affecting the request. */
@@ -243,8 +243,8 @@ template<>
 struct FsEvent<details::UVFsType::SCANDIR>
         : Event<FsEvent<details::UVFsType::SCANDIR>>
 {
-    FsEvent(const char *_path, std::size_t _size) noexcept
-        : path{_path}, size{_size}
+    FsEvent(const char *_path, std::size_t sz) noexcept
+        : path{_path}, size{sz}
     {}
 
     const char * path; /*!< The path affecting the request. */
@@ -262,8 +262,8 @@ template<>
 struct FsEvent<details::UVFsType::READLINK>
         : Event<FsEvent<details::UVFsType::READLINK>>
 {
-    explicit FsEvent(const char *_path, const char *_data, std::size_t _size) noexcept
-        : path{_path}, data{_data}, size{_size}
+    explicit FsEvent(const char *_path, const char *_data, std::size_t sz) noexcept
+        : path{_path}, data{_data}, size{sz}
     {}
 
     const char * path; /*!< The path affecting the request. */

--- a/src/uvw/fs.hpp
+++ b/src/uvw/fs.hpp
@@ -112,7 +112,7 @@ enum class UVDirentTypeT: std::underlying_type_t<uv_dirent_type_t> {
  */
 template<details::UVFsType e>
 struct FsEvent: Event<FsEvent<e>> {
-    FsEvent(const char *path) noexcept: path{path} {}
+    FsEvent(const char *_path) noexcept: path{_path} {}
 
     const char * path; /*!< The path affecting the request. */
 };
@@ -128,8 +128,8 @@ template<>
 struct FsEvent<details::UVFsType::READ>
         : Event<FsEvent<details::UVFsType::READ>>
 {
-    FsEvent(const char *path, std::unique_ptr<const char[]> data, std::size_t size) noexcept
-        : path{path}, data{std::move(data)}, size{size}
+    FsEvent(const char *_path, std::unique_ptr<const char[]> _data, std::size_t _size) noexcept
+        : path{_path}, data{std::move(_data)}, size{_size}
     {}
 
     const char * path; /*!< The path affecting the request. */
@@ -148,8 +148,8 @@ template<>
 struct FsEvent<details::UVFsType::WRITE>
         : Event<FsEvent<details::UVFsType::WRITE>>
 {
-    FsEvent(const char *path, std::size_t size) noexcept
-        : path{path}, size{size}
+    FsEvent(const char *_path, std::size_t _size) noexcept
+        : path{_path}, size{_size}
     {}
 
     const char * path; /*!< The path affecting the request. */
@@ -167,8 +167,8 @@ template<>
 struct FsEvent<details::UVFsType::SENDFILE>
         : Event<FsEvent<details::UVFsType::SENDFILE>>
 {
-    FsEvent(const char *path, std::size_t size) noexcept
-        : path{path}, size{size}
+    FsEvent(const char *_path, std::size_t _size) noexcept
+        : path{_path}, size{_size}
     {}
 
     const char * path; /*!< The path affecting the request. */
@@ -186,8 +186,8 @@ template<>
 struct FsEvent<details::UVFsType::STAT>
         : Event<FsEvent<details::UVFsType::STAT>>
 {
-    FsEvent(const char *path, Stat stat) noexcept
-        : path{path}, stat{std::move(stat)}
+    FsEvent(const char *_path, Stat _stat) noexcept
+        : path{_path}, stat{std::move(_stat)}
     {}
 
     const char * path; /*!< The path affecting the request. */
@@ -205,8 +205,8 @@ template<>
 struct FsEvent<details::UVFsType::FSTAT>
         : Event<FsEvent<details::UVFsType::FSTAT>>
 {
-    FsEvent(const char *path, Stat stat) noexcept
-        : path{path}, stat{std::move(stat)}
+    FsEvent(const char *_path, Stat _stat) noexcept
+        : path{_path}, stat{std::move(_stat)}
     {}
 
     const char * path; /*!< The path affecting the request. */
@@ -224,8 +224,8 @@ template<>
 struct FsEvent<details::UVFsType::LSTAT>
         : Event<FsEvent<details::UVFsType::LSTAT>>
 {
-    FsEvent(const char *path, Stat stat) noexcept
-        : path{path}, stat{std::move(stat)}
+    FsEvent(const char *_path, Stat _stat) noexcept
+        : path{_path}, stat{std::move(_stat)}
     {}
 
     const char * path; /*!< The path affecting the request. */
@@ -243,8 +243,8 @@ template<>
 struct FsEvent<details::UVFsType::SCANDIR>
         : Event<FsEvent<details::UVFsType::SCANDIR>>
 {
-    FsEvent(const char *path, std::size_t size) noexcept
-        : path{path}, size{size}
+    FsEvent(const char *_path, std::size_t _size) noexcept
+        : path{_path}, size{_size}
     {}
 
     const char * path; /*!< The path affecting the request. */
@@ -262,8 +262,8 @@ template<>
 struct FsEvent<details::UVFsType::READLINK>
         : Event<FsEvent<details::UVFsType::READLINK>>
 {
-    explicit FsEvent(const char *path, const char *data, std::size_t size) noexcept
-        : path{path}, data{data}, size{size}
+    explicit FsEvent(const char *_path, const char *_data, std::size_t _size) noexcept
+        : path{_path}, data{_data}, size{_size}
     {}
 
     const char * path; /*!< The path affecting the request. */
@@ -474,8 +474,8 @@ public:
      * @param len The lenght of the submitted data.
      * @param offset Offset, as described in the official documentation.
      */
-    void write(std::unique_ptr<char[]> data, std::size_t len, int64_t offset) {
-        this->data = std::move(data);
+    void write(std::unique_ptr<char[]> _data, std::size_t len, int64_t offset) {
+        this->data = std::move(_data);
         uv_buf_t bufs[] = { uv_buf_init(this->data.get(), len) };
         cleanupAndInvoke(&uv_fs_write, parent(), get(), file, bufs, 1, offset, &fsResultCallback<Type::WRITE>);
     }
@@ -493,8 +493,8 @@ public:
      * @param len The lenght of the submitted data.
      * @param offset Offset, as described in the official documentation.
      */
-    void write(char *data, std::size_t len, int64_t offset) {
-        uv_buf_t bufs[] = { uv_buf_init(data, len) };
+    void write(char *_data, std::size_t len, int64_t offset) {
+        uv_buf_t bufs[] = { uv_buf_init(_data, len) };
         cleanupAndInvoke(&uv_fs_write, parent(), get(), file, bufs, 1, offset, &fsResultCallback<Type::WRITE>);
     }
 
@@ -509,8 +509,8 @@ public:
      * * A boolean value that is true in case of success, false otherwise.
      * * The amount of data written to the given path.
      */
-    std::pair<bool, std::size_t> writeSync(std::unique_ptr<char[]> data, std::size_t len, int64_t offset) {
-        this->data = std::move(data);
+    std::pair<bool, std::size_t> writeSync(std::unique_ptr<char[]> _data, std::size_t len, int64_t offset) {
+        this->data = std::move(_data);
         uv_buf_t bufs[] = { uv_buf_init(this->data.get(), len) };
         auto req = get();
         cleanupAndInvokeSync(&uv_fs_write, parent(), req, file, bufs, 1, offset);

--- a/src/uvw/fs_event.hpp
+++ b/src/uvw/fs_event.hpp
@@ -39,8 +39,8 @@ enum class UVFsEvent: std::underlying_type_t<uv_fs_event> {
  * It will be emitted by FsEventHandle according with its functionalities.
  */
 struct FsEventEvent: Event<FsEventEvent> {
-    FsEventEvent(const char * filename, Flags<details::UVFsEvent> flags)
-        : filename{filename}, flags{std::move(flags)}
+    FsEventEvent(const char * _filename, Flags<details::UVFsEvent> _flags)
+        : filename{_filename}, flags{std::move(_flags)}
     {}
 
     /**

--- a/src/uvw/fs_event.hpp
+++ b/src/uvw/fs_event.hpp
@@ -39,8 +39,8 @@ enum class UVFsEvent: std::underlying_type_t<uv_fs_event> {
  * It will be emitted by FsEventHandle according with its functionalities.
  */
 struct FsEventEvent: Event<FsEventEvent> {
-    FsEventEvent(const char * _filename, Flags<details::UVFsEvent> _flags)
-        : filename{_filename}, flags{std::move(_flags)}
+    FsEventEvent(const char * pathname, Flags<details::UVFsEvent> events)
+        : filename{pathname}, flags{std::move(events)}
     {}
 
     /**

--- a/src/uvw/fs_poll.hpp
+++ b/src/uvw/fs_poll.hpp
@@ -20,8 +20,8 @@ namespace uvw {
  * It will be emitted by FsPollHandle according with its functionalities.
  */
 struct FsPollEvent: Event<FsPollEvent> {
-    explicit FsPollEvent(Stat prev, Stat curr) noexcept
-        : prev{std::move(prev)}, curr{std::move(curr)}
+    explicit FsPollEvent(Stat _prev, Stat _curr) noexcept
+        : prev{std::move(_prev)}, curr{std::move(_curr)}
     {}
 
     Stat prev; /*!< The old Stat struct. */

--- a/src/uvw/fs_poll.hpp
+++ b/src/uvw/fs_poll.hpp
@@ -20,8 +20,8 @@ namespace uvw {
  * It will be emitted by FsPollHandle according with its functionalities.
  */
 struct FsPollEvent: Event<FsPollEvent> {
-    explicit FsPollEvent(Stat _prev, Stat _curr) noexcept
-        : prev{std::move(_prev)}, curr{std::move(_curr)}
+    explicit FsPollEvent(Stat previous, Stat current) noexcept
+        : prev{std::move(previous)}, curr{std::move(current)}
     {}
 
     Stat prev; /*!< The old Stat struct. */

--- a/src/uvw/poll.hpp
+++ b/src/uvw/poll.hpp
@@ -32,8 +32,8 @@ enum class UVPollEvent: std::underlying_type_t<uv_poll_event> {
  * It will be emitted by PollHandle according with its functionalities.
  */
 struct PollEvent: Event<PollEvent> {
-    explicit PollEvent(Flags<details::UVPollEvent> _flags) noexcept
-        : flags{std::move(_flags)}
+    explicit PollEvent(Flags<details::UVPollEvent> events) noexcept
+        : flags{std::move(events)}
     {}
 
     /**

--- a/src/uvw/poll.hpp
+++ b/src/uvw/poll.hpp
@@ -32,8 +32,8 @@ enum class UVPollEvent: std::underlying_type_t<uv_poll_event> {
  * It will be emitted by PollHandle according with its functionalities.
  */
 struct PollEvent: Event<PollEvent> {
-    explicit PollEvent(Flags<details::UVPollEvent> flags) noexcept
-        : flags{std::move(flags)}
+    explicit PollEvent(Flags<details::UVPollEvent> _flags) noexcept
+        : flags{std::move(_flags)}
     {}
 
     /**

--- a/src/uvw/stream.hpp
+++ b/src/uvw/stream.hpp
@@ -62,8 +62,8 @@ struct WriteEvent: Event<WriteEvent> {};
  * It will be emitted by StreamHandle according with its functionalities.
  */
 struct DataEvent: Event<DataEvent> {
-    explicit DataEvent(std::unique_ptr<char[]> data, std::size_t length) noexcept
-        : data{std::move(data)}, length{length}
+    explicit DataEvent(std::unique_ptr<char[]> _data, std::size_t _length) noexcept
+        : data{std::move(_data)}, length{_length}
     {}
 
     std::unique_ptr<char[]> data; /*!< A bunch of data read on the stream. */
@@ -97,10 +97,10 @@ class WriteReq final: public Request<WriteReq, uv_write_t> {
 public:
     using Deleter = void(*)(uv_buf_t *);
 
-    WriteReq(ConstructorAccess ca, std::shared_ptr<Loop> loop, std::unique_ptr<uv_buf_t[], Deleter> bufs, std::size_t nbufs)
+    WriteReq(ConstructorAccess ca, std::shared_ptr<Loop> loop, std::unique_ptr<uv_buf_t[], Deleter> _bufs, std::size_t _nbufs)
         : Request<WriteReq, uv_write_t>{std::move(ca), std::move(loop)},
-          bufs{std::move(bufs)},
-          nbufs{nbufs}
+          bufs{std::move(_bufs)},
+          nbufs{_nbufs}
     {}
 
     void write(uv_stream_t *handle) {
@@ -251,7 +251,7 @@ public:
      * @param len The lenght of the submitted data.
      */
     void write(std::unique_ptr<char[]> data, std::size_t len) {
-        auto write = this->loop().template resource<details::WriteReq>(
+        auto _write = this->loop().template resource<details::WriteReq>(
                     std::unique_ptr<uv_buf_t[], details::WriteReq::Deleter>{
                         new uv_buf_t[1]{ uv_buf_init(data.release(), len) },
                         [](uv_buf_t *bufs) { delete[] bufs->base; delete[] bufs; }
@@ -261,9 +261,9 @@ public:
             ptr->publish(event);
         };
 
-        write->template once<ErrorEvent>(listener);
-        write->template once<WriteEvent>(listener);
-        write->write(this->template get<uv_stream_t>());
+        _write->template once<ErrorEvent>(listener);
+        _write->template once<WriteEvent>(listener);
+        _write->write(this->template get<uv_stream_t>());
     }
 
     /**
@@ -279,7 +279,7 @@ public:
      * @param len The lenght of the submitted data.
      */
     void write(char *data, std::size_t len) {
-        auto write = this->loop().template resource<details::WriteReq>(
+        auto _write = this->loop().template resource<details::WriteReq>(
                     std::unique_ptr<uv_buf_t[], details::WriteReq::Deleter>{
                         new uv_buf_t[1]{ uv_buf_init(data, len) },
                         [](uv_buf_t *bufs) { delete[] bufs; }
@@ -289,9 +289,9 @@ public:
             ptr->publish(event);
         };
 
-        write->template once<ErrorEvent>(listener);
-        write->template once<WriteEvent>(listener);
-        write->write(this->template get<uv_stream_t>());
+        _write->template once<ErrorEvent>(listener);
+        _write->template once<WriteEvent>(listener);
+        _write->write(this->template get<uv_stream_t>());
     }
 
     /**
@@ -315,7 +315,7 @@ public:
      */
     template<typename S>
     void write(S &send, std::unique_ptr<char[]> data, std::size_t len) {
-        auto write = this->loop().template resource<details::WriteReq>(
+        auto _write = this->loop().template resource<details::WriteReq>(
                     std::unique_ptr<uv_buf_t[], details::WriteReq::Deleter>{
                         new uv_buf_t[1]{ uv_buf_init(data.release(), len) },
                         [](uv_buf_t *bufs) { delete[] bufs->base; delete[] bufs; }
@@ -325,9 +325,9 @@ public:
             ptr->publish(event);
         };
 
-        write->template once<ErrorEvent>(listener);
-        write->template once<WriteEvent>(listener);
-        write->write(this->template get<uv_stream_t>(), send.template get<uv_stream_t>());
+        _write->template once<ErrorEvent>(listener);
+        _write->template once<WriteEvent>(listener);
+        _write->write(this->template get<uv_stream_t>(), send.template get<uv_stream_t>());
     }
 
     /**
@@ -351,7 +351,7 @@ public:
      */
     template<typename S>
     void write(S &send, char *data, std::size_t len) {
-        auto write = this->loop().template resource<details::WriteReq>(
+        auto _write = this->loop().template resource<details::WriteReq>(
                     std::unique_ptr<uv_buf_t[], details::WriteReq::Deleter>{
                         new uv_buf_t[1]{ uv_buf_init(data, len) },
                         [](uv_buf_t *bufs) { delete[] bufs; }
@@ -361,9 +361,9 @@ public:
             ptr->publish(event);
         };
 
-        write->template once<ErrorEvent>(listener);
-        write->template once<WriteEvent>(listener);
-        write->write(this->template get<uv_stream_t>(), send.template get<uv_stream_t>());
+        _write->template once<ErrorEvent>(listener);
+        _write->template once<WriteEvent>(listener);
+        _write->write(this->template get<uv_stream_t>(), send.template get<uv_stream_t>());
     }
 
     /**

--- a/src/uvw/stream.hpp
+++ b/src/uvw/stream.hpp
@@ -62,8 +62,8 @@ struct WriteEvent: Event<WriteEvent> {};
  * It will be emitted by StreamHandle according with its functionalities.
  */
 struct DataEvent: Event<DataEvent> {
-    explicit DataEvent(std::unique_ptr<char[]> _data, std::size_t _length) noexcept
-        : data{std::move(_data)}, length{_length}
+    explicit DataEvent(std::unique_ptr<char[]> buf, std::size_t len) noexcept
+        : data{std::move(buf)}, length{len}
     {}
 
     std::unique_ptr<char[]> data; /*!< A bunch of data read on the stream. */
@@ -97,10 +97,10 @@ class WriteReq final: public Request<WriteReq, uv_write_t> {
 public:
     using Deleter = void(*)(uv_buf_t *);
 
-    WriteReq(ConstructorAccess ca, std::shared_ptr<Loop> loop, std::unique_ptr<uv_buf_t[], Deleter> _bufs, std::size_t _nbufs)
+    WriteReq(ConstructorAccess ca, std::shared_ptr<Loop> loop, std::unique_ptr<uv_buf_t[], Deleter> data, std::size_t ndata)
         : Request<WriteReq, uv_write_t>{std::move(ca), std::move(loop)},
-          bufs{std::move(_bufs)},
-          nbufs{_nbufs}
+          bufs{std::move(data)},
+          nbufs{ndata}
     {}
 
     void write(uv_stream_t *handle) {
@@ -251,7 +251,7 @@ public:
      * @param len The lenght of the submitted data.
      */
     void write(std::unique_ptr<char[]> data, std::size_t len) {
-        auto _write = this->loop().template resource<details::WriteReq>(
+        auto req = this->loop().template resource<details::WriteReq>(
                     std::unique_ptr<uv_buf_t[], details::WriteReq::Deleter>{
                         new uv_buf_t[1]{ uv_buf_init(data.release(), len) },
                         [](uv_buf_t *bufs) { delete[] bufs->base; delete[] bufs; }
@@ -261,9 +261,9 @@ public:
             ptr->publish(event);
         };
 
-        _write->template once<ErrorEvent>(listener);
-        _write->template once<WriteEvent>(listener);
-        _write->write(this->template get<uv_stream_t>());
+        req->template once<ErrorEvent>(listener);
+        req->template once<WriteEvent>(listener);
+        req->write(this->template get<uv_stream_t>());
     }
 
     /**
@@ -279,7 +279,7 @@ public:
      * @param len The lenght of the submitted data.
      */
     void write(char *data, std::size_t len) {
-        auto _write = this->loop().template resource<details::WriteReq>(
+        auto req = this->loop().template resource<details::WriteReq>(
                     std::unique_ptr<uv_buf_t[], details::WriteReq::Deleter>{
                         new uv_buf_t[1]{ uv_buf_init(data, len) },
                         [](uv_buf_t *bufs) { delete[] bufs; }
@@ -289,9 +289,9 @@ public:
             ptr->publish(event);
         };
 
-        _write->template once<ErrorEvent>(listener);
-        _write->template once<WriteEvent>(listener);
-        _write->write(this->template get<uv_stream_t>());
+        req->template once<ErrorEvent>(listener);
+        req->template once<WriteEvent>(listener);
+        req->write(this->template get<uv_stream_t>());
     }
 
     /**
@@ -315,7 +315,7 @@ public:
      */
     template<typename S>
     void write(S &send, std::unique_ptr<char[]> data, std::size_t len) {
-        auto _write = this->loop().template resource<details::WriteReq>(
+        auto req = this->loop().template resource<details::WriteReq>(
                     std::unique_ptr<uv_buf_t[], details::WriteReq::Deleter>{
                         new uv_buf_t[1]{ uv_buf_init(data.release(), len) },
                         [](uv_buf_t *bufs) { delete[] bufs->base; delete[] bufs; }
@@ -325,9 +325,9 @@ public:
             ptr->publish(event);
         };
 
-        _write->template once<ErrorEvent>(listener);
-        _write->template once<WriteEvent>(listener);
-        _write->write(this->template get<uv_stream_t>(), send.template get<uv_stream_t>());
+        req->template once<ErrorEvent>(listener);
+        req->template once<WriteEvent>(listener);
+        req->write(this->template get<uv_stream_t>(), send.template get<uv_stream_t>());
     }
 
     /**
@@ -351,7 +351,7 @@ public:
      */
     template<typename S>
     void write(S &send, char *data, std::size_t len) {
-        auto _write = this->loop().template resource<details::WriteReq>(
+        auto req = this->loop().template resource<details::WriteReq>(
                     std::unique_ptr<uv_buf_t[], details::WriteReq::Deleter>{
                         new uv_buf_t[1]{ uv_buf_init(data, len) },
                         [](uv_buf_t *bufs) { delete[] bufs; }
@@ -361,9 +361,9 @@ public:
             ptr->publish(event);
         };
 
-        _write->template once<ErrorEvent>(listener);
-        _write->template once<WriteEvent>(listener);
-        _write->write(this->template get<uv_stream_t>(), send.template get<uv_stream_t>());
+        req->template once<ErrorEvent>(listener);
+        req->template once<WriteEvent>(listener);
+        req->write(this->template get<uv_stream_t>(), send.template get<uv_stream_t>());
     }
 
     /**

--- a/src/uvw/tcp.hpp
+++ b/src/uvw/tcp.hpp
@@ -74,8 +74,8 @@ public:
      *
      * @param sock A valid socket handle (either a file descriptor or a SOCKET).
      */
-    void open(OSSocketHandle sock) {
-        invoke(&uv_tcp_open, get(), sock);
+    void open(OSSocketHandle _sock) {
+        invoke(&uv_tcp_open, get(), _sock);
     }
 
     /**
@@ -133,10 +133,10 @@ public:
      * @param flags Optional additional flags.
      */
     template<typename I = IPv4>
-    void bind(std::string ip, unsigned int port, Flags<Bind> flags = Flags<Bind>{}) {
+    void bind(std::string ip, unsigned int port, Flags<Bind> _flags = Flags<Bind>{}) {
         typename details::IpTraits<I>::Type addr;
         details::IpTraits<I>::addrFunc(ip.data(), port, &addr);
-        invoke(&uv_tcp_bind, get(), reinterpret_cast<const sockaddr *>(&addr), flags);
+        invoke(&uv_tcp_bind, get(), reinterpret_cast<const sockaddr *>(&addr), _flags);
     }
 
     /**
@@ -156,8 +156,8 @@ public:
      * @param flags Optional additional flags.
      */
     template<typename I = IPv4>
-    void bind(Addr addr, Flags<Bind> flags = Flags<Bind>{}) {
-        bind<I>(addr.ip, addr.port, flags);
+    void bind(Addr addr, Flags<Bind> _flags = Flags<Bind>{}) {
+        bind<I>(addr.ip, addr.port, _flags);
     }
 
     /**
@@ -197,10 +197,10 @@ public:
             ptr->publish(event);
         };
 
-        auto connect = loop().resource<details::ConnectReq>();
-        connect->once<ErrorEvent>(listener);
-        connect->once<ConnectEvent>(listener);
-        connect->connect(&uv_tcp_connect, get(), reinterpret_cast<const sockaddr *>(&addr));
+        auto _connect = loop().resource<details::ConnectReq>();
+        _connect->once<ErrorEvent>(listener);
+        _connect->once<ConnectEvent>(listener);
+        _connect->connect(&uv_tcp_connect, get(), reinterpret_cast<const sockaddr *>(&addr));
     }
 
     /**

--- a/src/uvw/tcp.hpp
+++ b/src/uvw/tcp.hpp
@@ -72,10 +72,10 @@ public:
      * The passed file descriptor or SOCKET is not checked for its type, but
      * it’s required that it represents a valid stream socket.
      *
-     * @param sock A valid socket handle (either a file descriptor or a SOCKET).
+     * @param socket A valid socket handle (either a file descriptor or a SOCKET).
      */
-    void open(OSSocketHandle _sock) {
-        invoke(&uv_tcp_open, get(), _sock);
+    void open(OSSocketHandle socket) {
+        invoke(&uv_tcp_open, get(), socket);
     }
 
     /**
@@ -133,10 +133,10 @@ public:
      * @param flags Optional additional flags.
      */
     template<typename I = IPv4>
-    void bind(std::string ip, unsigned int port, Flags<Bind> _flags = Flags<Bind>{}) {
+    void bind(std::string ip, unsigned int port, Flags<Bind> opts = Flags<Bind>{}) {
         typename details::IpTraits<I>::Type addr;
         details::IpTraits<I>::addrFunc(ip.data(), port, &addr);
-        invoke(&uv_tcp_bind, get(), reinterpret_cast<const sockaddr *>(&addr), _flags);
+        invoke(&uv_tcp_bind, get(), reinterpret_cast<const sockaddr *>(&addr), opts);
     }
 
     /**
@@ -156,8 +156,8 @@ public:
      * @param flags Optional additional flags.
      */
     template<typename I = IPv4>
-    void bind(Addr addr, Flags<Bind> _flags = Flags<Bind>{}) {
-        bind<I>(addr.ip, addr.port, _flags);
+    void bind(Addr addr, Flags<Bind> opts = Flags<Bind>{}) {
+        bind<I>(addr.ip, addr.port, opts);
     }
 
     /**
@@ -197,10 +197,10 @@ public:
             ptr->publish(event);
         };
 
-        auto _connect = loop().resource<details::ConnectReq>();
-        _connect->once<ErrorEvent>(listener);
-        _connect->once<ConnectEvent>(listener);
-        _connect->connect(&uv_tcp_connect, get(), reinterpret_cast<const sockaddr *>(&addr));
+        auto req = loop().resource<details::ConnectReq>();
+        req->once<ErrorEvent>(listener);
+        req->once<ConnectEvent>(listener);
+        req->connect(&uv_tcp_connect, get(), reinterpret_cast<const sockaddr *>(&addr));
     }
 
     /**

--- a/src/uvw/tcp.hpp
+++ b/src/uvw/tcp.hpp
@@ -130,7 +130,7 @@ public:
      *
      * @param ip The address to which to bind.
      * @param port The port to which to bind.
-     * @param flags Optional additional flags.
+     * @param opts Optional additional flags.
      */
     template<typename I = IPv4>
     void bind(std::string ip, unsigned int port, Flags<Bind> opts = Flags<Bind>{}) {
@@ -153,7 +153,7 @@ public:
      * IPv6 is used.
      *
      * @param addr A valid instance of Addr.
-     * @param flags Optional additional flags.
+     * @param opts Optional additional flags.
      */
     template<typename I = IPv4>
     void bind(Addr addr, Flags<Bind> opts = Flags<Bind>{}) {

--- a/src/uvw/udp.hpp
+++ b/src/uvw/udp.hpp
@@ -32,8 +32,8 @@ struct SendEvent: Event<SendEvent> {};
  * It will be emitted by UDPHandle according with its functionalities.
  */
 struct UDPDataEvent: Event<UDPDataEvent> {
-    explicit UDPDataEvent(Addr sender, std::unique_ptr<const char[]> data, std::size_t length, bool partial) noexcept
-        : data{std::move(data)}, length{length}, sender{std::move(sender)}, partial{partial}
+    explicit UDPDataEvent(Addr _sender, std::unique_ptr<const char[]> _data, std::size_t _length, bool _partial) noexcept
+        : data{std::move(_data)}, length{_length}, sender{std::move(_sender)}, partial{_partial}
     {}
 
     std::unique_ptr<const char[]> data; /*!< A bunch of data read on the stream. */
@@ -62,10 +62,10 @@ class SendReq final: public Request<SendReq, uv_udp_send_t> {
 public:
     using Deleter = void(*)(uv_buf_t *);
 
-    SendReq(ConstructorAccess ca, std::shared_ptr<Loop> loop, std::unique_ptr<uv_buf_t[], Deleter> bufs, std::size_t nbufs)
+    SendReq(ConstructorAccess ca, std::shared_ptr<Loop> loop, std::unique_ptr<uv_buf_t[], Deleter> _bufs, std::size_t _nbufs)
         : Request<SendReq, uv_udp_send_t>{std::move(ca), std::move(loop)},
-          bufs{std::move(bufs)},
-          nbufs{nbufs}
+          bufs{std::move(_bufs)},
+          nbufs{_nbufs}
     {}
 
     void send(uv_udp_t *handle, const struct sockaddr* addr) {
@@ -154,8 +154,8 @@ public:
      *
      * @param sock A valid socket handle (either a file descriptor or a SOCKET).
      */
-    void open(OSSocketHandle sock) {
-        invoke(&uv_udp_open, get(), sock);
+    void open(OSSocketHandle _sock) {
+        invoke(&uv_udp_open, get(), _sock);
     }
 
     /**
@@ -175,10 +175,10 @@ public:
      * @param flags Optional additional flags.
      */
     template<typename I = IPv4>
-    void bind(std::string ip, unsigned int port, Flags<Bind> flags = Flags<Bind>{}) {
+    void bind(std::string ip, unsigned int port, Flags<Bind> _flags = Flags<Bind>{}) {
         typename details::IpTraits<I>::Type addr;
         details::IpTraits<I>::addrFunc(ip.data(), port, &addr);
-        invoke(&uv_udp_bind, get(), reinterpret_cast<const sockaddr *>(&addr), flags);
+        invoke(&uv_udp_bind, get(), reinterpret_cast<const sockaddr *>(&addr), _flags);
     }
 
     /**
@@ -197,8 +197,8 @@ public:
      * @param flags Optional additional flags.
      */
     template<typename I = IPv4>
-    void bind(Addr addr, Flags<Bind> flags = Flags<Bind>{}) {
-        bind<I>(addr.ip, addr.port, flags);
+    void bind(Addr addr, Flags<Bind> _flags = Flags<Bind>{}) {
+        bind<I>(addr.ip, addr.port, _flags);
     }
 
     /**
@@ -300,7 +300,7 @@ public:
         typename details::IpTraits<I>::Type addr;
         details::IpTraits<I>::addrFunc(ip.data(), port, &addr);
 
-        auto send = loop().resource<details::SendReq>(
+        auto _send = loop().resource<details::SendReq>(
                     std::unique_ptr<uv_buf_t[], details::SendReq::Deleter>{
                         new uv_buf_t[1]{ uv_buf_init(data.release(), len) },
                         [](uv_buf_t *bufs) { delete[] bufs->base; delete[] bufs; }
@@ -310,9 +310,9 @@ public:
             ptr->publish(event);
         };
 
-        send->once<ErrorEvent>(listener);
-        send->once<SendEvent>(listener);
-        send->send(get(), reinterpret_cast<const sockaddr *>(&addr));
+        _send->once<ErrorEvent>(listener);
+        _send->once<SendEvent>(listener);
+        _send->send(get(), reinterpret_cast<const sockaddr *>(&addr));
     }
 
     /**
@@ -338,7 +338,7 @@ public:
         typename details::IpTraits<I>::Type addr;
         details::IpTraits<I>::addrFunc(ip.data(), port, &addr);
 
-        auto send = loop().resource<details::SendReq>(
+        auto _send = loop().resource<details::SendReq>(
                     std::unique_ptr<uv_buf_t[], details::SendReq::Deleter>{
                         new uv_buf_t[1]{ uv_buf_init(data, len) },
                         [](uv_buf_t *bufs) { delete[] bufs; }
@@ -348,9 +348,9 @@ public:
             ptr->publish(event);
         };
 
-        send->once<ErrorEvent>(listener);
-        send->once<SendEvent>(listener);
-        send->send(get(), reinterpret_cast<const sockaddr *>(&addr));
+        _send->once<ErrorEvent>(listener);
+        _send->once<SendEvent>(listener);
+        _send->send(get(), reinterpret_cast<const sockaddr *>(&addr));
     }
 
     /**

--- a/src/uvw/udp.hpp
+++ b/src/uvw/udp.hpp
@@ -152,7 +152,7 @@ public:
      * [documentation](http://docs.libuv.org/en/v1.x/udp.html#c.uv_udp_open)
      * for further details.
      *
-     * @param sck A valid socket handle (either a file descriptor or a SOCKET).
+     * @param socket A valid socket handle (either a file descriptor or a SOCKET).
      */
     void open(OSSocketHandle socket) {
         invoke(&uv_udp_open, get(), socket);

--- a/src/uvw/udp.hpp
+++ b/src/uvw/udp.hpp
@@ -32,8 +32,8 @@ struct SendEvent: Event<SendEvent> {};
  * It will be emitted by UDPHandle according with its functionalities.
  */
 struct UDPDataEvent: Event<UDPDataEvent> {
-    explicit UDPDataEvent(Addr _sender, std::unique_ptr<const char[]> _data, std::size_t _length, bool _partial) noexcept
-        : data{std::move(_data)}, length{_length}, sender{std::move(_sender)}, partial{_partial}
+    explicit UDPDataEvent(Addr sndr, std::unique_ptr<const char[]> buf, std::size_t len, bool part) noexcept
+        : data{std::move(buf)}, length{len}, sender{std::move(sndr)}, partial{part}
     {}
 
     std::unique_ptr<const char[]> data; /*!< A bunch of data read on the stream. */
@@ -62,10 +62,10 @@ class SendReq final: public Request<SendReq, uv_udp_send_t> {
 public:
     using Deleter = void(*)(uv_buf_t *);
 
-    SendReq(ConstructorAccess ca, std::shared_ptr<Loop> loop, std::unique_ptr<uv_buf_t[], Deleter> _bufs, std::size_t _nbufs)
+    SendReq(ConstructorAccess ca, std::shared_ptr<Loop> loop, std::unique_ptr<uv_buf_t[], Deleter> data, std::size_t ndata)
         : Request<SendReq, uv_udp_send_t>{std::move(ca), std::move(loop)},
-          bufs{std::move(_bufs)},
-          nbufs{_nbufs}
+          bufs{std::move(data)},
+          nbufs{ndata}
     {}
 
     void send(uv_udp_t *handle, const struct sockaddr* addr) {
@@ -152,10 +152,10 @@ public:
      * [documentation](http://docs.libuv.org/en/v1.x/udp.html#c.uv_udp_open)
      * for further details.
      *
-     * @param sock A valid socket handle (either a file descriptor or a SOCKET).
+     * @param sck A valid socket handle (either a file descriptor or a SOCKET).
      */
-    void open(OSSocketHandle _sock) {
-        invoke(&uv_udp_open, get(), _sock);
+    void open(OSSocketHandle socket) {
+        invoke(&uv_udp_open, get(), socket);
     }
 
     /**
@@ -172,13 +172,13 @@ public:
      *
      * @param ip The IP address to which to bind.
      * @param port The port to which to bind.
-     * @param flags Optional additional flags.
+     * @param opts Optional additional flags.
      */
     template<typename I = IPv4>
-    void bind(std::string ip, unsigned int port, Flags<Bind> _flags = Flags<Bind>{}) {
+    void bind(std::string ip, unsigned int port, Flags<Bind> opts = Flags<Bind>{}) {
         typename details::IpTraits<I>::Type addr;
         details::IpTraits<I>::addrFunc(ip.data(), port, &addr);
-        invoke(&uv_udp_bind, get(), reinterpret_cast<const sockaddr *>(&addr), _flags);
+        invoke(&uv_udp_bind, get(), reinterpret_cast<const sockaddr *>(&addr), opts);
     }
 
     /**
@@ -194,11 +194,11 @@ public:
      * for further details.
      *
      * @param addr A valid instance of Addr.
-     * @param flags Optional additional flags.
+     * @param opts Optional additional flags.
      */
     template<typename I = IPv4>
-    void bind(Addr addr, Flags<Bind> _flags = Flags<Bind>{}) {
-        bind<I>(addr.ip, addr.port, _flags);
+    void bind(Addr addr, Flags<Bind> opts = Flags<Bind>{}) {
+        bind<I>(addr.ip, addr.port, opts);
     }
 
     /**
@@ -300,7 +300,7 @@ public:
         typename details::IpTraits<I>::Type addr;
         details::IpTraits<I>::addrFunc(ip.data(), port, &addr);
 
-        auto _send = loop().resource<details::SendReq>(
+        auto req = loop().resource<details::SendReq>(
                     std::unique_ptr<uv_buf_t[], details::SendReq::Deleter>{
                         new uv_buf_t[1]{ uv_buf_init(data.release(), len) },
                         [](uv_buf_t *bufs) { delete[] bufs->base; delete[] bufs; }
@@ -310,9 +310,9 @@ public:
             ptr->publish(event);
         };
 
-        _send->once<ErrorEvent>(listener);
-        _send->once<SendEvent>(listener);
-        _send->send(get(), reinterpret_cast<const sockaddr *>(&addr));
+        req->once<ErrorEvent>(listener);
+        req->once<SendEvent>(listener);
+        req->send(get(), reinterpret_cast<const sockaddr *>(&addr));
     }
 
     /**
@@ -338,7 +338,7 @@ public:
         typename details::IpTraits<I>::Type addr;
         details::IpTraits<I>::addrFunc(ip.data(), port, &addr);
 
-        auto _send = loop().resource<details::SendReq>(
+        auto req = loop().resource<details::SendReq>(
                     std::unique_ptr<uv_buf_t[], details::SendReq::Deleter>{
                         new uv_buf_t[1]{ uv_buf_init(data, len) },
                         [](uv_buf_t *bufs) { delete[] bufs; }
@@ -348,9 +348,9 @@ public:
             ptr->publish(event);
         };
 
-        _send->once<ErrorEvent>(listener);
-        _send->once<SendEvent>(listener);
-        _send->send(get(), reinterpret_cast<const sockaddr *>(&addr));
+        req->once<ErrorEvent>(listener);
+        req->once<SendEvent>(listener);
+        req->send(get(), reinterpret_cast<const sockaddr *>(&addr));
     }
 
     /**

--- a/src/uvw/util.hpp
+++ b/src/uvw/util.hpp
@@ -185,7 +185,7 @@ using RUsage = uv_rusage_t;
 
 
 struct Passwd {
-    Passwd(std::shared_ptr<uv_passwd_t> _passwd): passwd{_passwd} {}
+    Passwd(std::shared_ptr<uv_passwd_t> pwd): passwd{pwd} {}
 
     std::string username() const noexcept { return passwd->username; }
     Uid uid() const noexcept { return passwd->uid; }

--- a/src/uvw/util.hpp
+++ b/src/uvw/util.hpp
@@ -185,7 +185,7 @@ using RUsage = uv_rusage_t;
 
 
 struct Passwd {
-    Passwd(std::shared_ptr<uv_passwd_t> passwd): passwd{passwd} {}
+    Passwd(std::shared_ptr<uv_passwd_t> _passwd): passwd{_passwd} {}
 
     std::string username() const noexcept { return passwd->username; }
     Uid uid() const noexcept { return passwd->uid; }


### PR DESCRIPTION
GCC is spawning a lot of warnings about shadowed parameters. This PR fixes all of those.

Renamed shadowed members errors like:
`warning: declaration of ‘path’ shadows a member of ‘uvw::FsEvent<(uvw::details::UVFsType)10>’ [-Wshadow]`