### PR TITLE
Fix -Wc++11-narrowing error/warning

### DIFF
--- a/src/uvw/udp.hpp
+++ b/src/uvw/udp.hpp
@@ -108,12 +108,12 @@ class UDPHandle final: public Handle<UDPHandle, uv_udp_t> {
 
         if(nread > 0) {
             // data available (can be truncated)
-            udp.publish(UDPDataEvent{details::address<I>(aptr), std::move(data), static_cast<size_t>(nread), static_cast<bool>(flags & UV_UDP_PARTIAL)});
+            udp.publish(UDPDataEvent{details::address<I>(aptr), std::move(data), static_cast<std::size_t>(nread), static_cast<bool>(flags & UV_UDP_PARTIAL)});
         } else if(nread == 0 && addr == nullptr) {
             // no more data to be read, doing nothing is fine
         } else if(nread == 0 && addr != nullptr) {
             // empty udp packet
-            udp.publish(UDPDataEvent{details::address<I>(aptr), std::move(data), static_cast<size_t>(nread), false});
+            udp.publish(UDPDataEvent{details::address<I>(aptr), std::move(data), static_cast<std::size_t>(nread), false});
         } else {
             // transmission error
             udp.publish(ErrorEvent(nread));

--- a/src/uvw/udp.hpp
+++ b/src/uvw/udp.hpp
@@ -108,12 +108,12 @@ class UDPHandle final: public Handle<UDPHandle, uv_udp_t> {
 
         if(nread > 0) {
             // data available (can be truncated)
-            udp.publish(UDPDataEvent{details::address<I>(aptr), std::move(data), nread, flags & UV_UDP_PARTIAL});
+            udp.publish(UDPDataEvent{details::address<I>(aptr), std::move(data), static_cast<size_t>(nread), static_cast<bool>(flags & UV_UDP_PARTIAL)});
         } else if(nread == 0 && addr == nullptr) {
             // no more data to be read, doing nothing is fine
         } else if(nread == 0 && addr != nullptr) {
             // empty udp packet
-            udp.publish(UDPDataEvent{details::address<I>(aptr), std::move(data), nread, false});
+            udp.publish(UDPDataEvent{details::address<I>(aptr), std::move(data), static_cast<size_t>(nread), false});
         } else {
             // transmission error
             udp.publish(ErrorEvent(nread));


### PR DESCRIPTION
Fix a warning with GCC/Linux and a build error with Clang/macOS.

```
udp.hpp:111:82: error: non-constant-expression cannot be narrowed from type 'ssize_t' (aka 'long') to 'std::size_t' (aka 'unsigned long') in initializer list [-Wc++11-narrowing]
        note: insert an explicit cast to silence this issue

udp.hpp:111:89: error: non-constant-expression cannot be narrowed from type 'unsigned int' to 'bool' in initializer list [-Wc++11-narrowing]
        note: insert an explicit cast to silence this issue

udp.hpp:116:82: error: non-constant-expression cannot be narrowed from type 'ssize_t' (aka 'long') to 'std::size_t' (aka 'unsigned long') in initializer list [-Wc++11-narrowing]
        note: insert an explicit cast to silence this issue
```