### PR TITLE
uv_spawn: Do not set cwd to an empty string

### DIFF
--- a/src/uvw/process.hpp
+++ b/src/uvw/process.hpp
@@ -123,7 +123,9 @@ public:
         po.args = args;
         po.env = env;
 
-        po.cwd = poCwd.data();
+        if (!poCwd.empty()) {
+            po.cwd = poCwd.data();
+        }
         po.flags = poFlags;
         po.stdio_count = poStdio.size();
         po.stdio = poStdio.data();

--- a/src/uvw/process.hpp
+++ b/src/uvw/process.hpp
@@ -122,10 +122,7 @@ public:
         po.file = file;
         po.args = args;
         po.env = env;
-
-        if (!poCwd.empty()) {
-            po.cwd = poCwd.data();
-        }
+        po.cwd = poCwd.empty() ? nullptr : poCwd.data();
         po.flags = poFlags;
         po.stdio_count = poStdio.size();
         po.stdio = poStdio.data();


### PR DESCRIPTION
If po.cwd is set to an empty string the process failed to start with an error.