### PR TITLE
Fix -wshadow warning

### DIFF
--- a/src/uvw/udp.hpp
+++ b/src/uvw/udp.hpp
@@ -301,7 +301,7 @@ public:
 
         auto req = loop().resource<details::SendReq>(
                     std::unique_ptr<char[], details::SendReq::Deleter>{
-                        data.release(), [](char *ptr) { delete[] ptr; }
+                        data.release(), [](char *aptr) { delete[] aptr; }
                     }, len);
 
         auto listener = [ptr = shared_from_this()](const auto &event, const auto &) {


### PR DESCRIPTION
Fix warning

```
../../../src/lib/uvw/src/uvw/udp.hpp: In lambda function:
../../../src/lib/uvw/src/uvw/udp.hpp:304:53: warning: declaration of ‘ptr’ shadows a member of ‘uvw::UDPHandle’ [-Wshadow]
                         data.release(), [](char *ptr) { delete[] ptr; }
                                                     ^
In file included from ../../../src/lib/uvw/src/uvw/handle.hpp:8:0,
                 from ../../../src/lib/uvw/src/uvw/async.hpp:7,
                 from ../../../src/lib/uvw/src/uvw.hpp:1,
                 from JsonApiHandlerHttp.cpp:32:
../../../src/lib/uvw/src/uvw/resource.hpp:129:38: note: shadowed declaration is here
     std::shared_ptr<void> ptr{nullptr};
                                      ^

```