### PR TITLE
Common create method

### DIFF
--- a/src/uvw/lib.hpp
+++ b/src/uvw/lib.hpp
@@ -7,7 +7,7 @@
 #include <utility>
 #include <uv.h>
 #include "loop.hpp"
-#include "resource_base.hpp"
+#include "underlying_type.hpp"
 
 
 namespace uvw {
@@ -19,7 +19,7 @@ namespace uvw {
  * `uvw` provides cross platform utilities for loading shared libraries and
  * retrieving symbols from them, by means of the API offered by `libuv`.
  */
-class SharedLib final: public ResourceBase<SharedLib, uv_lib_t> {
+class SharedLib final: public UnderlyingType<SharedLib, uv_lib_t> {
 public:
     /**
      * @brief Creates a new shared library object.
@@ -28,7 +28,7 @@ public:
      * @return A pointer to the newly created handle.
      */
     explicit SharedLib(ConstructorAccess ca, std::shared_ptr<Loop> ref, std::string filename) noexcept
-        : ResourceBase{std::move(ca), std::move(ref)}
+        : UnderlyingType{std::move(ca), std::move(ref)}
     {
         opened = (0 == uv_dlopen(filename.data(), get()));
     }

--- a/src/uvw/resource.hpp
+++ b/src/uvw/resource.hpp
@@ -4,7 +4,7 @@
 #include <memory>
 #include <utility>
 #include "emitter.hpp"
-#include "resource_base.hpp"
+#include "underlying_type.hpp"
 
 
 namespace uvw {
@@ -14,10 +14,10 @@ namespace uvw {
  * @brief Common class for almost all the resources available in `uvw`.
  *
  * This is the base class for handles and requests.<br/>
- * Beyond `ResourceBase`, it stores a UserData and a self-referencing shared_ptr.
+ * Beyond `UnderlyingType`, it stores a UserData and a self-referencing shared_ptr.
  */
 template<typename T, typename U>
-class Resource: public ResourceBase<T, U>, public Emitter<T>,
+class Resource: public UnderlyingType<T, U>, public Emitter<T>,
                 public std::enable_shared_from_this<T> {
 
 protected:
@@ -38,9 +38,9 @@ protected:
     }
 
 public:
-    explicit Resource(typename ResourceBase<T, U>::ConstructorAccess ca,
+    explicit Resource(typename UnderlyingType<T, U>::ConstructorAccess ca,
                       std::shared_ptr<Loop> ref)
-        : ResourceBase<T, U>{std::move(ca), std::move(ref)},
+        : UnderlyingType<T, U>{std::move(ca), std::move(ref)},
           Emitter<T>{},
           std::enable_shared_from_this<T>{}
     {

--- a/src/uvw/resource.hpp
+++ b/src/uvw/resource.hpp
@@ -38,8 +38,9 @@ protected:
     }
 
 public:
-    explicit Resource(ConstructorAccess ca, std::shared_ptr<Loop> ref)
-        : ResourceBase{std::move(ca), std::move(ref)},
+    explicit Resource(typename ResourceBase<T, U>::ConstructorAccess ca,
+                      std::shared_ptr<Loop> ref)
+        : ResourceBase<T, U>{std::move(ca), std::move(ref)},
           Emitter<T>{},
           std::enable_shared_from_this<T>{}
     {

--- a/src/uvw/resource.hpp
+++ b/src/uvw/resource.hpp
@@ -1,11 +1,10 @@
 #pragma once
 
 
-#include <utility>
 #include <memory>
-#include <uv.h>
+#include <utility>
 #include "emitter.hpp"
-#include "loop.hpp"
+#include "resource_base.hpp"
 
 
 namespace uvw {
@@ -15,48 +14,15 @@ namespace uvw {
  * @brief Common class for almost all the resources available in `uvw`.
  *
  * This is the base class for handles and requests.<br/>
- * It mainly acts as a wrapper around a data structure of `libuv`.
+ * Beyond `ResourceBase`, it stores a UserData and a self-referencing shared_ptr.
  */
 template<typename T, typename U>
-class Resource: public Emitter<T>, public std::enable_shared_from_this<T> {
-    template<typename, typename>
-    friend class Resource;
+class Resource: public ResourceBase<T, U>, public Emitter<T>,
+                public std::enable_shared_from_this<T> {
 
 protected:
-    struct ConstructorAccess { explicit ConstructorAccess(int) {} };
-
     auto parent() const noexcept {
-        return pLoop->loop.get();
-    }
-
-    auto get() noexcept {
-        return &resource;
-    }
-
-    auto get() const noexcept {
-        return const_cast<const U *>(&resource);
-    }
-
-    template<typename R>
-    auto get() noexcept {
-        static_assert(not std::is_same<R, U>::value, "!");
-        return reinterpret_cast<R *>(&resource);
-    }
-
-    template<typename R, typename... P>
-    auto get(Resource<P...> &res) noexcept {
-        return reinterpret_cast<R *>(&res.resource);
-    }
-
-    template<typename R>
-    auto get() const noexcept {
-        static_assert(not std::is_same<R, U>::value, "!");
-        return reinterpret_cast<const R *>(&resource);
-    }
-
-    template<typename R, typename... P>
-    auto get(const Resource<P...> &res) const noexcept {
-        return reinterpret_cast<const R *>(&res.resource);
+        return this->loop().loop.get();
     }
 
     void leak() noexcept {
@@ -72,40 +38,13 @@ protected:
     }
 
 public:
-    explicit Resource(ConstructorAccess, std::shared_ptr<Loop> ref)
-        : Emitter<T>{},
-          std::enable_shared_from_this<T>{},
-          pLoop{std::move(ref)},
-          resource{}
+    explicit Resource(ConstructorAccess ca, std::shared_ptr<Loop> ref)
+        : ResourceBase{std::move(ca), std::move(ref)},
+          Emitter<T>{},
+          std::enable_shared_from_this<T>{}
     {
-        resource.data = static_cast<T*>(this);
+        this->get()->data = static_cast<T*>(this);
     }
-
-    Resource(const Resource &) = delete;
-    Resource(Resource &&) = delete;
-
-    virtual ~Resource() {
-        static_assert(std::is_base_of<Resource<T, U>, T>::value, "!");
-    }
-
-    Resource & operator=(const Resource &) = delete;
-    Resource & operator=(Resource &&) = delete;
-
-    /**
-     * @brief Creates a new resource of the given type.
-     * @param args Arguments to be forwarded to the actual constructor (if any).
-     * @return A pointer to the newly created resource.
-     */
-    template<typename... Args>
-    static std::shared_ptr<T> create(Args&&... args) {
-        return std::make_shared<T>(ConstructorAccess{0}, std::forward<Args>(args)...);
-    }
-
-    /**
-     * @brief Gets the loop from which the resource was originated.
-     * @return A reference to a loop instance.
-     */
-    Loop & loop() const noexcept { return *pLoop; }
 
     /**
      * @brief Gets user-defined data. `uvw` won't use this field in any case.
@@ -127,8 +66,6 @@ public:
 private:
     std::shared_ptr<void> userData{nullptr};
     std::shared_ptr<void> sPtr{nullptr};
-    std::shared_ptr<Loop> pLoop;
-    U resource;
 };
 
 

--- a/src/uvw/resource_base.hpp
+++ b/src/uvw/resource_base.hpp
@@ -1,0 +1,93 @@
+#pragma once
+
+
+#include <memory>
+#include <utility>
+#include "loop.hpp"
+
+
+namespace uvw {
+
+
+/**
+ * @brief Internal `class uvw::ResourceBase`
+ *
+ * A base resource class to define the `create` method in one place.<br/>
+ * It mainly acts as a wrapper around a data structure of `libuv`.
+ */
+template<typename T, typename U>
+class ResourceBase {
+    template<typename, typename>
+    friend class ResourceBase;
+
+protected:
+    struct ConstructorAccess { explicit ConstructorAccess(int) {} };
+
+    auto get() noexcept {
+        return &resource;
+    }
+
+    auto get() const noexcept {
+        return &resource;
+    }
+
+    template<typename R>
+    auto get() noexcept {
+        static_assert(not std::is_same<R, U>::value, "!");
+        return reinterpret_cast<R *>(&resource);
+    }
+
+    template<typename R>
+    auto get() const noexcept {
+        static_assert(not std::is_same<R, U>::value, "!");
+        return reinterpret_cast<const R *>(&resource);
+    }
+
+    template<typename R, typename... P>
+    static auto get(ResourceBase<P...> &res) noexcept {
+        return reinterpret_cast<R *>(&res.resource);
+    }
+
+    template<typename R, typename... P>
+    static auto get(const ResourceBase<P...> &res) noexcept {
+        return reinterpret_cast<const R *>(&res.resource);
+    }
+
+public:
+    explicit ResourceBase(ConstructorAccess, std::shared_ptr<Loop> ref) noexcept
+        : pLoop{std::move(ref)}, resource{}
+    {}
+
+    ResourceBase(const ResourceBase &) = delete;
+    ResourceBase(ResourceBase &&) = delete;
+
+    virtual ~ResourceBase() {
+        static_assert(std::is_base_of<ResourceBase<T, U>, T>::value, "!");
+    }
+
+    ResourceBase & operator=(const ResourceBase &) = delete;
+    ResourceBase & operator=(ResourceBase &&) = delete;
+
+    /**
+     * @brief Creates a new resource of the given type.
+     * @param args Arguments to be forwarded to the actual constructor (if any).
+     * @return A pointer to the newly created resource.
+     */
+    template<typename... Args>
+    static std::shared_ptr<T> create(Args&&... args) {
+        return std::make_shared<T>(ConstructorAccess{0}, std::forward<Args>(args)...);
+    }
+
+    /**
+     * @brief Gets the loop from which the resource was originated.
+     * @return A reference to a loop instance.
+     */
+    Loop & loop() const noexcept { return *pLoop; }
+
+private:
+    std::shared_ptr<Loop> pLoop;
+    U resource;
+};
+
+
+}

--- a/src/uvw/resource_base.hpp
+++ b/src/uvw/resource_base.hpp
@@ -18,9 +18,6 @@ namespace uvw {
  */
 template<typename T, typename U>
 class ResourceBase {
-    template<typename, typename>
-    friend class ResourceBase;
-
 protected:
     struct ConstructorAccess { explicit ConstructorAccess(int) {} };
 
@@ -42,16 +39,6 @@ protected:
     auto get() const noexcept {
         static_assert(not std::is_same<R, U>::value, "!");
         return reinterpret_cast<const R *>(&resource);
-    }
-
-    template<typename R, typename... P>
-    static auto get(ResourceBase<P...> &res) noexcept {
-        return reinterpret_cast<R *>(&res.resource);
-    }
-
-    template<typename R, typename... P>
-    static auto get(const ResourceBase<P...> &res) noexcept {
-        return reinterpret_cast<const R *>(&res.resource);
     }
 
 public:

--- a/src/uvw/resource_base.hpp
+++ b/src/uvw/resource_base.hpp
@@ -2,6 +2,7 @@
 
 
 #include <memory>
+#include <type_traits>
 #include <utility>
 #include "loop.hpp"
 

--- a/src/uvw/thread.hpp
+++ b/src/uvw/thread.hpp
@@ -7,7 +7,7 @@
 #include <utility>
 #include <uv.h>
 #include "loop.hpp"
-#include "resource_base.hpp"
+#include "underlying_type.hpp"
 
 
 namespace uvw {
@@ -23,7 +23,7 @@ class Condition;
 class Barrier;
 
 
-class Thread final: public ResourceBase<Thread, uv_thread_t> {
+class Thread final: public UnderlyingType<Thread, uv_thread_t> {
     using InternalTask = std::function<void(std::shared_ptr<void>)>;
 
     static void createCallback(void *arg) {
@@ -37,7 +37,7 @@ public:
 
     explicit Thread(ConstructorAccess ca, std::shared_ptr<Loop> ref,
                     InternalTask t, std::shared_ptr<void> d = nullptr) noexcept
-        : ResourceBase{std::move(ca), std::move(ref)}, data{std::move(d)}, task{std::move(t)}
+        : UnderlyingType{std::move(ca), std::move(ref)}, data{std::move(d)}, task{std::move(t)}
     {}
 
     static Type self() noexcept {
@@ -66,39 +66,39 @@ private:
 };
 
 
-class ThreadLocalStorage final: public ResourceBase<ThreadLocalStorage, uv_key_t> {
+class ThreadLocalStorage final: public UnderlyingType<ThreadLocalStorage, uv_key_t> {
 public:
     explicit ThreadLocalStorage(ConstructorAccess ca, std::shared_ptr<Loop> ref) noexcept
-        : ResourceBase{std::move(ca), std::move(ref)}
+        : UnderlyingType{std::move(ca), std::move(ref)}
     {
-        uv_key_create(ResourceBase::get());
+        uv_key_create(UnderlyingType::get());
     }
 
     ~ThreadLocalStorage() noexcept {
-        uv_key_delete(ResourceBase::get());
+        uv_key_delete(UnderlyingType::get());
     }
 
     template<typename T>
     T* get() noexcept {
-        return static_cast<T*>(uv_key_get(ResourceBase::get()));
+        return static_cast<T*>(uv_key_get(UnderlyingType::get()));
     }
 
     template<typename T>
     void set(T *value) noexcept {
-        return uv_key_set(ResourceBase::get(), value);
+        return uv_key_set(UnderlyingType::get(), value);
     }
 };
 
 
 // `Once` is an odd one as it doesn't use a `libuv` structure per object.
-class Once final: public ResourceBase<Once, uv_once_t> {
+class Once final: public UnderlyingType<Once, uv_once_t> {
     static uv_once_t* guard() noexcept {
         static uv_once_t once = UV_ONCE_INIT;
         return &once;
     }
 
 public:
-    using ResourceBase::ResourceBase;
+    using UnderlyingType::UnderlyingType;
 
     template<typename F>
     static void once(F &&f) noexcept {
@@ -110,12 +110,12 @@ public:
 };
 
 
-class Mutex final: public ResourceBase<Mutex, uv_mutex_t> {
+class Mutex final: public UnderlyingType<Mutex, uv_mutex_t> {
     friend class Condition;
 
 public:
     explicit Mutex(ConstructorAccess ca, std::shared_ptr<Loop> ref) noexcept
-        : ResourceBase{std::move(ca), std::move(ref)}
+        : UnderlyingType{std::move(ca), std::move(ref)}
     {
         uv_mutex_init(get());
     }
@@ -138,10 +138,10 @@ public:
 };
 
 
-class RWLock final: public ResourceBase<RWLock, uv_rwlock_t> {
+class RWLock final: public UnderlyingType<RWLock, uv_rwlock_t> {
 public:
     explicit RWLock(ConstructorAccess ca, std::shared_ptr<Loop> ref) noexcept
-        : ResourceBase{std::move(ca), std::move(ref)}
+        : UnderlyingType{std::move(ca), std::move(ref)}
     {
         uv_rwlock_init(get());
     }
@@ -176,10 +176,10 @@ public:
 };
 
 
-class Semaphore final: public ResourceBase<Semaphore, uv_sem_t> {
+class Semaphore final: public UnderlyingType<Semaphore, uv_sem_t> {
 public:
     explicit Semaphore(ConstructorAccess ca, std::shared_ptr<Loop> ref, unsigned int value) noexcept
-        : ResourceBase{std::move(ca), std::move(ref)}
+        : UnderlyingType{std::move(ca), std::move(ref)}
     {
         uv_sem_init(get(), value);
     }
@@ -202,10 +202,10 @@ public:
 };
 
 
-class Condition final: public ResourceBase<Condition, uv_cond_t> {
+class Condition final: public UnderlyingType<Condition, uv_cond_t> {
 public:
     explicit Condition(ConstructorAccess ca, std::shared_ptr<Loop> ref) noexcept
-        : ResourceBase{std::move(ca), std::move(ref)}
+        : UnderlyingType{std::move(ca), std::move(ref)}
     {
         uv_cond_init(get());
     }
@@ -232,10 +232,10 @@ public:
 };
 
 
-class Barrier final: public ResourceBase<Barrier, uv_barrier_t> {
+class Barrier final: public UnderlyingType<Barrier, uv_barrier_t> {
 public:
     explicit Barrier(ConstructorAccess ca, std::shared_ptr<Loop> ref, unsigned int count) noexcept
-        : ResourceBase{std::move(ca), std::move(ref)}
+        : UnderlyingType{std::move(ca), std::move(ref)}
     {
         uv_barrier_init(get(), count);
     }

--- a/src/uvw/underlying_type.hpp
+++ b/src/uvw/underlying_type.hpp
@@ -11,13 +11,13 @@ namespace uvw {
 
 
 /**
- * @brief Internal `class uvw::ResourceBase`
+ * @brief Internal `class uvw::UnderlyingType`
  *
  * A base resource class to define the `create` method in one place.<br/>
  * It mainly acts as a wrapper around a data structure of `libuv`.
  */
 template<typename T, typename U>
-class ResourceBase {
+class UnderlyingType {
 protected:
     struct ConstructorAccess { explicit ConstructorAccess(int) {} };
 
@@ -42,19 +42,19 @@ protected:
     }
 
 public:
-    explicit ResourceBase(ConstructorAccess, std::shared_ptr<Loop> ref) noexcept
+    explicit UnderlyingType(ConstructorAccess, std::shared_ptr<Loop> ref) noexcept
         : pLoop{std::move(ref)}, resource{}
     {}
 
-    ResourceBase(const ResourceBase &) = delete;
-    ResourceBase(ResourceBase &&) = delete;
+    UnderlyingType(const UnderlyingType &) = delete;
+    UnderlyingType(UnderlyingType &&) = delete;
 
-    virtual ~ResourceBase() {
-        static_assert(std::is_base_of<ResourceBase<T, U>, T>::value, "!");
+    virtual ~UnderlyingType() {
+        static_assert(std::is_base_of<UnderlyingType<T, U>, T>::value, "!");
     }
 
-    ResourceBase & operator=(const ResourceBase &) = delete;
-    ResourceBase & operator=(ResourceBase &&) = delete;
+    UnderlyingType & operator=(const UnderlyingType &) = delete;
+    UnderlyingType & operator=(UnderlyingType &&) = delete;
 
     /**
      * @brief Creates a new resource of the given type.


### PR DESCRIPTION
The advantage of having a common `create` method is that it consolidates the dynamic allocation of "resources" in `uvw`. This doesn't exhaust all instances, but reduces the usage of `new` in existing code.
An observable benefit of the change is the reduction of duplicate arguments to the `create` method and the class constructors.

**Change description:**
Consolidate the `<Type>::create` methods from various classes - `SharedLib`, `Thread` and others in a single base class. Also aggregate other similar functionality like getting the owning `Loop` object reference, getting the owned libuv structure pointer.
Since `class Resource` inherits `Emitter` and `std::enable_shared_from_this`, it isn't a feasible option. Therefore, `ResourceBase` (the name can be decided upon) is extracted from and inherited into `Resource`. This essentially means no API change in the final classes of `uvw`.