### PR TITLE
remove unnecessary using statement

### DIFF
--- a/src/uvw/tcp.hpp
+++ b/src/uvw/tcp.hpp
@@ -49,8 +49,6 @@ public:
     using IPv4 = uvw::IPv4;
     using IPv6 = uvw::IPv6;
 
-    using StreamHandle::StreamHandle;
-
     explicit TcpHandle(ConstructorAccess ca, std::shared_ptr<Loop> ref, unsigned int f)
         : StreamHandle{ca, std::move(ref)}, tag{FLAGS}, flags{f}
     {}


### PR DESCRIPTION
While trying to run our code through some static analysis tools, we were getting an error running.  It was eventually traced back to the line below.  Comparing with tty and pipe as well as an attempt to remove and retest our code leads us to believe this line is unnecessary.

Thoughts on removing it?