### PR TITLE
Implement equality checks and hashing for uvw::Addr

### DIFF
--- a/src/uvw/util.hpp
+++ b/src/uvw/util.hpp
@@ -5,6 +5,7 @@
 #include <algorithm>
 #include <stdexcept>
 #include <cstddef>
+#include <functional>
 #include <utility>
 #include <string>
 #include <vector>
@@ -299,6 +300,10 @@ struct IPv6 {};
 struct Addr {
     std::string ip; /*!< Either an IPv4 or an IPv6. */
     unsigned int port; /*!< A valid service identifier. */
+
+    bool operator==(const Addr &other) const {
+        return ip == other.ip && port == other.port;
+    }
 };
 
 
@@ -840,4 +845,16 @@ struct Utilities {
 };
 
 
+}
+
+
+namespace std {
+template <>
+struct hash<uvw::Addr> {
+    std::size_t operator()(const uvw::Addr &addr) const noexcept {
+        std::size_t h1 = std::hash<std::string>{}(addr.ip);
+        std::size_t h2 = std::hash<unsigned int>{}(addr.port);
+        return h1 ^ h2;
+    }
+};
 }

--- a/test/uvw/util.cpp
+++ b/test/uvw/util.cpp
@@ -1,4 +1,5 @@
 #include <memory>
+#include <unordered_set>
 #include <cstdlib>
 #include <gtest/gtest.h>
 #include <uvw.hpp>
@@ -156,4 +157,25 @@ TEST(Util, Utilities) {
     ASSERT_NE(uvw::Utilities::setupArgs(1, &argv), nullptr);
     ASSERT_NE(uvw::Utilities::processTitle(), std::string{});
     ASSERT_TRUE(uvw::Utilities::processTitle(uvw::Utilities::processTitle()));
+}
+
+
+TEST(Util, AddrHashing) {
+    const std::string ip = "127.0.0.1";
+    const unsigned int port = 80;
+    std::unordered_set<uvw::Addr> addrs;
+
+    uvw::Addr a;
+    a.ip = ip;
+    a.port = port;
+    addrs.insert(a);
+    ASSERT_EQ(addrs.size(), 1);
+
+    uvw::Addr b;
+    b.ip = ip;
+    b.port = port;
+    ASSERT_EQ(a, b);
+
+    addrs.erase(b);
+    ASSERT_EQ(addrs.size(), 0);
 }


### PR DESCRIPTION
Pretty self-explanatory.

For reasons that are not clear to me, line 172 of util.hpp (which checks that the set has size 1) generates a compiler warning (GCC 7.2.1):

```
In file included from /home/evan/code/uvw/test/uvw/util.cpp:4:0:
/home/evan/code/uvw/deps/googletest/src/googletest/include/gtest/gtest.h: In instantiation of ‘testing::AssertionResult testing::internal::CmpHelperEQ(const char*, const char*, const T1&, const T2&) [with T1 = long unsigned int; T2 = int]’:
/home/evan/code/uvw/deps/googletest/src/googletest/include/gtest/gtest.h:1421:23:   required from ‘static testing::AssertionResult testing::internal::EqHelper<lhs_is_null_literal>::Compare(const char*, const char*, const T1&, const T2&) [with T1 = long unsigned int; T2 = int; bool lhs_is_null_literal = false]’
/home/evan/code/uvw/test/uvw/util.cpp:172:5:   required from here
/home/evan/code/uvw/deps/googletest/src/googletest/include/gtest/gtest.h:1392:11: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
   if (lhs == rhs) {
```

The warning is harmless, but I couldn't figure out how to suppress it.