### PR TITLE
Check for nullptr before calling uv_thread_join

### DIFF
--- a/src/uvw/thread.hpp
+++ b/src/uvw/thread.hpp
@@ -48,7 +48,8 @@ public:
     }
 
     ~Thread() noexcept {
-        join();
+        auto ptr = get();
+        if (*ptr) uv_thread_join(ptr);
     }
 
     bool run() noexcept {


### PR DESCRIPTION
The "TODO" test for Thread crashes for me with a segfault, as `uv_thread_join()` doesn't check if it's given a null pointer. This change adds an extra check in `~Thread` before calling `uv_thread_join()`. Arguably this logic could be moved to `join()`, but I think it's reasonable to segfault if the user calls `join()` on an improperly initialized `Thread` object.

Below is the back trace I get from the test on master.

```
$ gdb ./test/bin/thread 
GNU gdb (GDB) Fedora 8.0.1-30.fc27
Copyright (C) 2017 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.  Type "show copying"
and "show warranty" for details.
This GDB was configured as "x86_64-redhat-linux-gnu".
Type "show configuration" for configuration details.
For bug reporting instructions, please see:
<http://www.gnu.org/software/gdb/bugs/>.
Find the GDB manual and other documentation resources online at:
<http://www.gnu.org/software/gdb/documentation/>.
For help, type "help".
Type "apropos word" to search for commands related to "word"...
Reading symbols from ./test/bin/thread...done.
(gdb) run
Starting program: /home/evan/code/uvw/build/test/bin/thread 
Missing separate debuginfos, use: dnf debuginfo-install glibc-2.26-16.fc27.x86_64
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/lib64/libthread_db.so.1".
Running main() from gtest_main.cc
[==========] Running 8 tests from 8 test cases.
[----------] Global test environment set-up.
[----------] 1 test from Thread
[ RUN      ] Thread.TODO

Program received signal SIGSEGV, Segmentation fault.
0x00007ffff70c4ace in pthread_join () from /lib64/libpthread.so.0
Missing separate debuginfos, use: dnf debuginfo-install libgcc-7.2.1-2.fc27.x86_64 libstdc++-7.2.1-2.fc27.x86_64
(gdb) bt
#0  0x00007ffff70c4ace in pthread_join () from /lib64/libpthread.so.0
#1  0x00000000004924ae in uv_thread_join (tid=<optimized out>) at src/unix/thread.c:212
#2  0x000000000047dfca in uvw::Thread::join (this=0x7192f0) at /home/evan/code/uvw/src/uvw/thread.hpp:59
#3  0x000000000047df3c in uvw::Thread::~Thread (this=0x7192f0, __in_chrg=<optimized out>) at /home/evan/code/uvw/src/uvw/thread.hpp:51
#4  0x0000000000488fc0 in __gnu_cxx::new_allocator<uvw::Thread>::destroy<uvw::Thread> (this=0x7192f0, __p=0x7192f0) at /usr/include/c++/7/ext/new_allocator.h:140
#5  0x0000000000488d29 in std::allocator_traits<std::allocator<uvw::Thread> >::destroy<uvw::Thread> (__a=..., __p=0x7192f0) at /usr/include/c++/7/bits/alloc_traits.h:487
#6  0x000000000048864f in std::_Sp_counted_ptr_inplace<uvw::Thread, std::allocator<uvw::Thread>, (__gnu_cxx::_Lock_policy)2>::_M_dispose (this=0x7192e0) at /usr/include/c++/7/bits/shared_ptr_base.h:535
#7  0x000000000047f872 in std::_Sp_counted_base<(__gnu_cxx::_Lock_policy)2>::_M_release (this=0x7192e0) at /usr/include/c++/7/bits/shared_ptr_base.h:154
#8  0x000000000047ea9d in std::__shared_count<(__gnu_cxx::_Lock_policy)2>::~__shared_count (this=0x7fffffffde88, __in_chrg=<optimized out>) at /usr/include/c++/7/bits/shared_ptr_base.h:684
#9  0x000000000047e66c in std::__shared_ptr<uvw::Thread, (__gnu_cxx::_Lock_policy)2>::~__shared_ptr (this=0x7fffffffde80, __in_chrg=<optimized out>) at /usr/include/c++/7/bits/shared_ptr_base.h:1123
#10 0x000000000047e688 in std::shared_ptr<uvw::Thread>::~shared_ptr (this=0x7fffffffde80, __in_chrg=<optimized out>) at /usr/include/c++/7/bits/shared_ptr.h:93
#11 0x000000000047ca27 in Thread_TODO_Test::TestBody (this=0x719110) at /home/evan/code/uvw/test/uvw/thread.cpp:9
#12 0x00000000004c2eff in testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void> (object=0x719110, method=&virtual testing::Test::TestBody(), location=0x4d5ddb "the test body")
    at /home/evan/code/uvw/deps/googletest/src/googletest/src/gtest.cc:2401
#13 0x00000000004bd768 in testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void> (object=0x719110, method=&virtual testing::Test::TestBody(), location=0x4d5ddb "the test body")
    at /home/evan/code/uvw/deps/googletest/src/googletest/src/gtest.cc:2437
#14 0x00000000004a3144 in testing::Test::Run (this=0x719110) at /home/evan/code/uvw/deps/googletest/src/googletest/src/gtest.cc:2473
#15 0x00000000004a39e4 in testing::TestInfo::Run (this=0x716f20) at /home/evan/code/uvw/deps/googletest/src/googletest/src/gtest.cc:2655
#16 0x00000000004a4009 in testing::TestCase::Run (this=0x717390) at /home/evan/code/uvw/deps/googletest/src/googletest/src/gtest.cc:2773
#17 0x00000000004aa9fc in testing::internal::UnitTestImpl::RunAllTests (this=0x717060) at /home/evan/code/uvw/deps/googletest/src/googletest/src/gtest.cc:4673
#18 0x00000000004c3f01 in testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool> (object=0x717060, 
    method=(bool (testing::internal::UnitTestImpl::*)(testing::internal::UnitTestImpl * const)) 0x4aa71c <testing::internal::UnitTestImpl::RunAllTests()>, location=0x4d6690 "auxiliary test code (environments or event listeners)")
    at /home/evan/code/uvw/deps/googletest/src/googletest/src/gtest.cc:2401
#19 0x00000000004be47e in testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool> (object=0x717060, 
    method=(bool (testing::internal::UnitTestImpl::*)(testing::internal::UnitTestImpl * const)) 0x4aa71c <testing::internal::UnitTestImpl::RunAllTests()>, location=0x4d6690 "auxiliary test code (environments or event listeners)")
    at /home/evan/code/uvw/deps/googletest/src/googletest/src/gtest.cc:2437
#20 0x00000000004a965c in testing::UnitTest::Run (this=0x704400 <testing::UnitTest::GetInstance()::instance>) at /home/evan/code/uvw/deps/googletest/src/googletest/src/gtest.cc:4281
#21 0x0000000000489335 in RUN_ALL_TESTS () at /home/evan/code/uvw/deps/googletest/src/googletest/include/gtest/gtest.h:2237
#22 0x00000000004892cf in main (argc=1, argv=0x7fffffffe378) at /home/evan/code/uvw/deps/googletest/src/googletest/src/gtest_main.cc:37
```