### PR TITLE
FEATURE: expose write_queue_size

### DIFF
--- a/src/uvw/stream.hpp
+++ b/src/uvw/stream.hpp
@@ -447,11 +447,11 @@ public:
     }
 
     /**
-     * @brief Warpper to access uv_stream_t.write_queue_size
+     * @brief Retrieves stream->write_queue_size
      * @return Amount of queued bytes waiting to be sent
      */
-    size_t get_write_queue_size() const noexcept {
-        return this->template get<uv_stream_t>()->write_queue_size;
+    size_t writeQueueSize() const noexcept {
+        return uv_stream_get_write_queue_size(this->template get<uv_stream_t>());
     }
 };
 

--- a/src/uvw/stream.hpp
+++ b/src/uvw/stream.hpp
@@ -445,6 +445,14 @@ public:
     bool blocking(bool enable = false) {
         return (0 == uv_stream_set_blocking(this->template get<uv_stream_t>(), enable));
     }
+
+    /**
+     * @brief Warpper to access uv_stream_t.write_queue_size
+     * @return Amount of queued bytes waiting to be sent
+     */
+    size_t get_write_queue_size() const noexcept {
+        return this->template get<uv_stream_t>()->write_queue_size;
+    }
 };
 
 

--- a/src/uvw/stream.hpp
+++ b/src/uvw/stream.hpp
@@ -447,8 +447,8 @@ public:
     }
 
     /**
-     * @brief Retrieves stream->write_queue_size
-     * @return Amount of queued bytes waiting to be sent
+     * @brief Gets the amount of queued bytes waiting to be sent.
+     * @return Amount of queued bytes waiting to be sent.
      */
     size_t writeQueueSize() const noexcept {
         return uv_stream_get_write_queue_size(this->template get<uv_stream_t>());

--- a/src/uvw/udp.hpp
+++ b/src/uvw/udp.hpp
@@ -593,6 +593,22 @@ public:
         invoke(&uv_udp_recv_stop, get());
     }
 
+    /**
+     * @brief Retrieves handle->send_queue_size
+     * @return Number of bytes queued for sending. This field strictly shows how much information is currently queued.
+     */
+    size_t sendQueueSize() const noexcept {
+        return uv_udp_get_send_queue_size(get());
+    }
+
+    /**
+     * @brief Retrieves handle->send_queue_count
+     * @return Number of send requests currently in the queue awaiting to be processed.
+     */
+    size_t sendQueueCount() const noexcept {
+        return uv_udp_get_send_queue_count(get());
+    }
+
 private:
     enum { DEFAULT, FLAGS } tag{DEFAULT};
     unsigned int flags{};

--- a/src/uvw/udp.hpp
+++ b/src/uvw/udp.hpp
@@ -594,16 +594,19 @@ public:
     }
 
     /**
-     * @brief Retrieves handle->send_queue_size
-     * @return Number of bytes queued for sending. This field strictly shows how much information is currently queued.
+     * @brief Gets the number of bytes queued for sending.
+     *
+     * It strictly shows how much information is currently queued.
+     *
+     * @return Number of bytes queued for sending.
      */
     size_t sendQueueSize() const noexcept {
         return uv_udp_get_send_queue_size(get());
     }
 
     /**
-     * @brief Retrieves handle->send_queue_count
-     * @return Number of send requests currently in the queue awaiting to be processed.
+     * @brief Number of send requests currently in the queue awaiting to be processed.
+     * @return Number of send requests currently in the queue.
      */
     size_t sendQueueCount() const noexcept {
         return uv_udp_get_send_queue_count(get());


### PR DESCRIPTION
There may be a better way to access member variables from the underlying libuv types but I'm not sure how to do it.