### PR TITLE
#135 Conan package support

### DIFF
--- a/.conan/build.py
+++ b/.conan/build.py
@@ -6,18 +6,13 @@ import re
 from cpt.packager import ConanMultiPackager
 
 
-def get_branch():
-    return os.getenv("TRAVIS_BRANCH", "master")
-
-
 def get_version():
     with open("CMakeLists.txt") as cmake:
         content = cmake.read()
         match = re.search(r'project\(uvw VERSION (.*)\)', content)
         if match:
             return match.group(1)
-    return get_branch()
-
+        return os.getenv("TRAVIS_BRANCH", "master")
 
 def get_username():
     return os.getenv("CONAN_USERNAME", "skypjack")
@@ -41,6 +36,7 @@ if __name__ == "__main__":
     builder = ConanMultiPackager(reference=get_reference(),
                                  username=get_username(),
                                  upload=get_upload(),
+                                 remote="https://api.bintray.com/conan/bincrafters/public-conan",
                                  test_folder=test_folder)
     builder.add(settings={"compiler": "gcc", "compiler.version": "7",
                           "arch": "x86_64", "build_type": "Release"},

--- a/.conan/build.py
+++ b/.conan/build.py
@@ -3,6 +3,7 @@
 
 import os
 import re
+import platform
 from cpt.packager import ConanMultiPackager
 
 
@@ -37,8 +38,10 @@ if __name__ == "__main__":
                                  username=get_username(),
                                  upload=get_upload(),
                                  remotes="https://api.bintray.com/conan/bincrafters/public-conan",
-                                 test_folder=test_folder)
-    builder.add(settings={"compiler": "gcc", "compiler.version": "7",
-                          "arch": "x86_64", "build_type": "Release"},
-                options={}, env_vars={}, build_requires={})
+                                 test_folder=test_folder,
+                                 stable_branch_pattern=r'v?\d+\.\d+\.\d+.*')
+    if platform.system() == "Linux":
+        builder.add(settings={"compiler": "gcc", "compiler.version": "8",
+                            "arch": "x86_64", "build_type": "Release"},
+                    options={}, env_vars={}, build_requires={})
     builder.run()

--- a/.conan/build.py
+++ b/.conan/build.py
@@ -36,7 +36,7 @@ if __name__ == "__main__":
     builder = ConanMultiPackager(reference=get_reference(),
                                  username=get_username(),
                                  upload=get_upload(),
-                                 remote="https://api.bintray.com/conan/bincrafters/public-conan",
+                                 remotes="https://api.bintray.com/conan/bincrafters/public-conan",
                                  test_folder=test_folder)
     builder.add(settings={"compiler": "gcc", "compiler.version": "7",
                           "arch": "x86_64", "build_type": "Release"},

--- a/.conan/build.py
+++ b/.conan/build.py
@@ -32,6 +32,10 @@ def get_upload():
     return os.getenv("CONAN_UPLOAD", default_upload)
 
 
+def upload_when_stable():
+    return os.getenv("CONAN_UPLOAD_ONLY_WHEN_STABLE", "1").lower() not in ["0", "false", "no"]
+
+
 if __name__ == "__main__":
     test_folder = os.path.join(".conan", "test_package")
     builder = ConanMultiPackager(reference=get_reference(),
@@ -39,7 +43,8 @@ if __name__ == "__main__":
                                  upload=get_upload(),
                                  remotes="https://api.bintray.com/conan/bincrafters/public-conan",
                                  test_folder=test_folder,
-                                 stable_branch_pattern=r'v?\d+\.\d+\.\d+.*')
+                                 stable_branch_pattern=r'v?\d+\.\d+\.\d+.*',
+                                 upload_only_when_stable=upload_when_stable())
     if platform.system() == "Linux":
         builder.add(settings={"compiler": "gcc", "compiler.version": "8",
                             "arch": "x86_64", "build_type": "Release"},

--- a/.conan/build.py
+++ b/.conan/build.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import os
+import re
+from cpt.packager import ConanMultiPackager
+
+
+def get_branch():
+    return os.getenv("TRAVIS_BRANCH", "master")
+
+
+def get_version():
+    with open("CMakeLists.txt") as cmake:
+        content = cmake.read()
+        match = re.search(r'project\(uvw VERSION (.*)\)', content)
+        if match:
+            return match.group(1)
+    return get_branch()
+
+
+def get_username():
+    return os.getenv("CONAN_USERNAME", "skypjack")
+
+
+def get_reference():
+    version = get_version()
+    username = get_username()
+    return "uvw/{}@{}/stable".format(version, username)
+
+
+def get_upload():
+    username = get_username()
+    url = "https://api.bintray.com/conan/{}/conan".format(username)
+    default_upload = url if os.getenv("TRAVIS_TAG") else False
+    return os.getenv("CONAN_UPLOAD", default_upload)
+
+
+if __name__ == "__main__":
+    test_folder = os.path.join(".conan", "test_package")
+    builder = ConanMultiPackager(reference=get_reference(),
+                                 username=get_username(),
+                                 upload=get_upload(),
+                                 test_folder=test_folder)
+    builder.add(settings={"compiler": "gcc", "compiler.version": "7",
+                          "arch": "x86_64", "build_type": "Release"},
+                options={}, env_vars={}, build_requires={})
+    builder.run()

--- a/.conan/test_package/CMakeLists.txt
+++ b/.conan/test_package/CMakeLists.txt
@@ -1,0 +1,10 @@
+project(test_package)
+cmake_minimum_required(VERSION 2.8)
+
+set(CMAKE_VERBOSE_MAKEFILE TRUE)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} CONAN_PKG::uvw)

--- a/.conan/test_package/conanfile.py
+++ b/.conan/test_package/conanfile.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import os
+from conans import ConanFile, CMake
+
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "cmake"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        test_package = os.path.join("bin", "test_package")
+        self.run(test_package, run_environment=True)

--- a/.conan/test_package/test_package.cpp
+++ b/.conan/test_package/test_package.cpp
@@ -1,0 +1,48 @@
+#include <cstdlib>
+#include <iostream>
+#include <uvw.hpp>
+#include <memory>
+
+void listen(uvw::Loop &loop) {
+    std::shared_ptr<uvw::TcpHandle> tcp = loop.resource<uvw::TcpHandle>();
+
+    tcp->once<uvw::ListenEvent>([](const uvw::ListenEvent &, uvw::TcpHandle &srv) {
+        std::shared_ptr<uvw::TcpHandle> client = srv.loop().resource<uvw::TcpHandle>();
+
+        client->on<uvw::CloseEvent>([ptr = srv.shared_from_this()](const uvw::CloseEvent &, uvw::TcpHandle &) { ptr->close(); });
+        client->on<uvw::EndEvent>([](const uvw::EndEvent &, uvw::TcpHandle &client) { client.close(); });
+
+        srv.accept(*client);
+        client->read();
+    });
+
+    tcp->bind("127.0.0.1", 4242);
+    tcp->listen();
+}
+
+void conn(uvw::Loop &loop) {
+    auto tcp = loop.resource<uvw::TcpHandle>();
+
+    tcp->on<uvw::ErrorEvent>([](const uvw::ErrorEvent &, uvw::TcpHandle &) { /* handle errors */ });
+
+    tcp->once<uvw::ConnectEvent>([](const uvw::ConnectEvent &, uvw::TcpHandle &tcp) {
+        auto dataWrite = std::unique_ptr<char[]>(new char[2]{ 'b', 'c' });
+        tcp.write(std::move(dataWrite), 2);
+        tcp.close();
+    });
+
+    tcp->connect(std::string{"127.0.0.1"}, 4242);
+}
+
+int main() {
+    std::cout << "Getting UVW loop ...\n";
+    auto loop = uvw::Loop::getDefault();
+    std::cout << "Staring UVW listener ...\n";
+    listen(*loop);
+    std::cout << "Connecting ...\n";
+    conn(*loop);
+    loop->run();
+    std::cout << "Done!\n";
+
+    return EXIT_SUCCESS;
+}

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 *.user
 
 TODO
+
+.conan/test_package/build

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,19 @@ matrix:
       - pip install --user cpp-coveralls
     after_success:
       - coveralls --gcov gcov-6 --gcov-options '\-lp' --root ${TRAVIS_BUILD_DIR} --build-root ${TRAVIS_BUILD_DIR}/build --extension cpp --extension hpp --exclude deps --include src
-
+  - os: linux
+    dist: xenial
+    language: python
+    python: "3.7"
+    services:
+      - docker
+    env:
+      - CONAN_GCC_VERSIONS=8
+      - CONAN_DOCKER_IMAGE=conanio/gcc8
+    install:
+      - pip install conan_package_tools
+    script:
+      - python .conan/build.py
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,7 @@ matrix:
       - coveralls --gcov gcov-6 --gcov-options '\-lp' --root ${TRAVIS_BUILD_DIR} --build-root ${TRAVIS_BUILD_DIR}/build --extension cpp --extension hpp --exclude deps --include src
   - os: linux
     dist: xenial
+    sudo: true
     language: python
     python: "3.7"
     services:

--- a/README.md
+++ b/README.md
@@ -6,10 +6,12 @@
 [![Build Status](https://travis-ci.org/skypjack/uvw.svg?branch=master)](https://travis-ci.org/skypjack/uvw)
 [![Build status](https://ci.appveyor.com/api/projects/status/m5ndm8gnu8isg2to?svg=true)](https://ci.appveyor.com/project/skypjack/uvw)
 [![Coverage Status](https://coveralls.io/repos/github/skypjack/uvw/badge.svg?branch=master)](https://coveralls.io/github/skypjack/uvw?branch=master)
+[![Download](https://api.bintray.com/packages/skypjack/conan/uvw%3Askypjack/images/download.svg)](https://bintray.com/skypjack/conan/uvw%3Askypjack/_latestVersion)
 [![Gitter chat](https://badges.gitter.im/skypjack/uvw.png)](https://gitter.im/skypjack/uvw)
 [![Donate](https://img.shields.io/badge/Donate-PayPal-green.svg)](https://www.paypal.com/cgi-bin/webscr?cmd=_donations&business=W2HF9FESD5LJY&lc=IT&item_name=Michele%20Caini&currency_code=EUR&bn=PP%2dDonationsBF%3abtn_donateCC_LG%2egif%3aNonHosted)
 
 [![Patreon](https://c5.patreon.com/external/logo/become_a_patron_button.png)](https://www.patreon.com/bePatron?u=11330786)
+
 <!--
 @endcond TURN_OFF_DOXYGEN
 -->

--- a/conanfile.py
+++ b/conanfile.py
@@ -13,7 +13,7 @@ class UVMConan(ConanFile):
     exports = "LICENSE"
     exports_sources = "src/*"
     no_copy_source = True
-    requires = "libuv/1.15.0@bincrafters/stable"
+    requires = "libuv/1.23.2@bincrafters/stable"
 
     def package(self):
         self.copy(pattern="LICENSE", dst="licenses")

--- a/conanfile.py
+++ b/conanfile.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+from conans import ConanFile
+
+
+class UVMConan(ConanFile):
+    name = "uvw"
+    description = "Header-only, event based, tiny and easy to use libuv wrapper in modern C++"
+    homepage = "https://github.com/skypjack/uvw"
+    url = homepage
+    license = "MIT"
+    author = "Michele Caini <michele.caini@gmail.com>"
+    exports = "LICENSE"
+    exports_sources = "src/*"
+    no_copy_source = True
+    requires = "libuv/1.15.0@bincrafters/stable"
+
+    def package(self):
+        self.copy(pattern="LICENSE", dst="licenses")
+        self.copy(pattern="*.hpp", dst="include", src="src")
+
+    def package_id(self):
+        self.info.header_only()


### PR DESCRIPTION
Hi!

This PR brings the support for Conan.

Including:
- .conan/build.py
  Build script to create Conan package on Travis CI
- .conan/test_package/CMakeLists.txt
  CMake file to build test package
- .conan/test_package/conanfile.py
  Conan recipe to build test package
- .conan/test_package/test_package.cpp
  Example code to consume Conan package created
- .travis.yml
  Update to run Conan job on CI
- conanfile.py
  Conan recipe to provide UVM package
- bintray badge on README
  Download link page for UVM package

Conan uses the file *conanfile.py* as recipe to execute all steps necessary to create the package. As your project is header-only it doesn't need build anything, just copy all headers and license. Conan defines the package id by settings + options and UVW is header-only so it doesn't need set anything.

To make sure that your package is working well, Conan provides test_package, where we put a simple example consuming your package and building as well. When test_package.cpp is including uvw header, all files are imported from the packaged provided by Conan. Test package is not for unit testing propose, it's a package validation.

When running your package on CI (appveyor, travis or any other) we could run Conan to create the package and check. But prepare a full environment with compiler, build-essential , conan and all stuff could be boring, so we use Docker. Conan provides a good range of images, including gcc and clang. Here I added only GCC 8 because we only need to create a package for any architecture or OS -- header-only project doesn't provide binaries by platform.

### How to upload?

Conan uses Bintray to store their packages. You need to create an account on bintray for that. There is a good documentation how to create a bintray account [here](https://docs.conan.io/en/latest/uploading_packages/bintray/uploading_bintray.html).

The build.py is configured following the reference *skypjack/conan/uvw/<version>*. Where:
- skypjack is your Bintray user name
- conan is the repository name
- uvw is the package name

Both username and repository you will need to set manually on web interface. Both username and repository could be changed by your preference, I just followed the convention.

Also, build.py has a rule to upload only tags or any branch with the pattern name "v\d+\.\d+\.\d+.*".

And finally, you must set the variable **CONAN_PASSWORD** on Travis settings. The password is the Bintray API Key, not your account password. To read your API key you need to access *https://bintray.com/profile/edit* and click on API Key button. Don't forget to mark as secret on Travis settings. 

After to upload your package by CI, we recommend update the Bintray package page:
*https://bintray.com/skypjack/conan/uvw%3Askypjack/edit?tab=general*
The page contains only project metadata, as url, maturity (official), license -- There is a field for package avatar, you could use conan-uvw logo with you prefer or uvw official. 

Okay, this is a lot of information. Please, feel free to ask anything.

I included @danimtb to review this PR. He is a Conan expert and maintainer.

Regards!

/cc @danimtb

closes #135 