### PR TITLE
#144 Remove Conan remotes

### DIFF
--- a/.conan/build.py
+++ b/.conan/build.py
@@ -41,7 +41,6 @@ if __name__ == "__main__":
     builder = ConanMultiPackager(reference=get_reference(),
                                  username=get_username(),
                                  upload=get_upload(),
-                                 remotes="https://api.bintray.com/conan/bincrafters/public-conan",
                                  test_folder=test_folder,
                                  stable_branch_pattern=r'v?\d+\.\d+\.\d+.*',
                                  upload_only_when_stable=upload_when_stable())

--- a/conanfile.py
+++ b/conanfile.py
@@ -9,6 +9,7 @@ class UVMConan(ConanFile):
     homepage = "https://github.com/skypjack/uvw"
     url = homepage
     license = "MIT"
+    topics = ("conan", "uvw", "libuv", "header-only", "wrapper", "event-loop")
     author = "Michele Caini <michele.caini@gmail.com>"
     exports = "LICENSE"
     exports_sources = "src/*"


### PR DESCRIPTION
Related issue #144

- Since liuv is official in Conan Center, we no longer need to force Bincrafters' remote in CPT list.
- Add topics attribute. All topics are present on Github project page.