### PR TITLE
Changed FsReq::stasfs method name to statfs

### DIFF
--- a/src/uvw/fs.hpp
+++ b/src/uvw/fs.hpp
@@ -1210,7 +1210,7 @@ public:
      *
      * @param path Path, as described in the official documentation.
      */
-    void stasfs(std::string path) {
+    void statfs(std::string path) {
         cleanupAndInvoke(&uv_fs_statfs, parent(), get(), path.data(), &fsStatfsCallback);
     }
 


### PR DESCRIPTION
I believe it was a small typo in the method name, as uv does name it uv_fs_statfs and the method name in Linux is also statfs