### PR TITLE
WIP: shared libs: export classes with functions implemented in .cpp files

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -74,8 +74,20 @@ add_uvw_library(uvw-static)
 add_library(uvw-shared SHARED)
 add_library(uvw::uvw-shared ALIAS uvw-shared)
 target_link_libraries(uvw-shared PUBLIC uv::uv-shared)
-set_target_properties(uvw-shared PROPERTIES VERSION ${PROJECT_VERSION} SOVERSION ${UVW_VERSION_MAJOR} EXCLUDE_FROM_DEFAULT_BUILD 1)
+set_target_properties(uvw-shared PROPERTIES
+	VERSION ${PROJECT_VERSION}
+	SOVERSION ${UVW_VERSION_MAJOR}
+	EXCLUDE_FROM_DEFAULT_BUILD 1
+	C_VISIBILITY_PRESET hidden
+	CXX_VISIBILITY_PRESET hidden
+)
 add_uvw_library(uvw-shared)
+target_compile_definitions(uvw-shared
+  INTERFACE
+    USING_UVW_SHARED=1
+  PRIVATE
+    BUILDING_UVW_SHARED=1
+)
 
 #
 # Install targets

--- a/src/uvw/async.h
+++ b/src/uvw/async.h
@@ -5,7 +5,9 @@
 #include <uv.h>
 #include "handle.hpp"
 #include "loop.h"
+#include "config.h"
 
+UVW_MSVC_WARNING_PUSH_DISABLE_DLLINTERFACE();
 
 namespace uvw {
 
@@ -15,7 +17,7 @@ namespace uvw {
  *
  * It will be emitted by AsyncHandle according with its functionalities.
  */
-struct AsyncEvent {};
+struct UVW_EXTERN AsyncEvent {};
 
 
 /**
@@ -26,7 +28,7 @@ struct AsyncEvent {};
  *
  * To create an `AsyncHandle` through a `Loop`, no arguments are required.
  */
-class AsyncHandle final: public Handle<AsyncHandle, uv_async_t> {
+class UVW_EXTERN AsyncHandle final : public Handle<AsyncHandle, uv_async_t> {
     static void sendCallback(uv_async_t *handle);
 
 public:
@@ -62,5 +64,7 @@ public:
 #ifndef UVW_AS_LIB
 #include "async.cpp"
 #endif
+
+UVW_MSVC_WARNING_POP();
 
 #endif // UVW_ASYNC_INCLUDE_H

--- a/src/uvw/async.h
+++ b/src/uvw/async.h
@@ -28,7 +28,7 @@ struct UVW_EXTERN AsyncEvent {};
  *
  * To create an `AsyncHandle` through a `Loop`, no arguments are required.
  */
-class UVW_EXTERN AsyncHandle final : public Handle<AsyncHandle, uv_async_t> {
+class UVW_EXTERN AsyncHandle final : public Handle<AsyncHandle, uv_async_t, AsyncEvent> {
     static void sendCallback(uv_async_t *handle);
 
 public:

--- a/src/uvw/check.h
+++ b/src/uvw/check.h
@@ -5,7 +5,9 @@
 #include <uv.h>
 #include "handle.hpp"
 #include "loop.h"
+#include "config.h"
 
+UVW_MSVC_WARNING_PUSH_DISABLE_DLLINTERFACE();
 
 namespace uvw {
 
@@ -15,7 +17,7 @@ namespace uvw {
  *
  * It will be emitted by CheckHandle according with its functionalities.
  */
-struct CheckEvent {};
+struct UVW_EXTERN CheckEvent {};
 
 
 /**
@@ -26,7 +28,7 @@ struct CheckEvent {};
  *
  * To create a `CheckHandle` through a `Loop`, no arguments are required.
  */
-class CheckHandle final: public Handle<CheckHandle, uv_check_t> {
+class UVW_EXTERN CheckHandle final : public Handle<CheckHandle, uv_check_t> {
     static void startCallback(uv_check_t *handle);
 
 public:
@@ -59,5 +61,7 @@ public:
 #ifndef UVW_AS_LIB
 #include "check.cpp"
 #endif
+
+UVW_MSVC_WARNING_POP();
 
 #endif // UVW_CHECK_INCLUDE_H

--- a/src/uvw/check.h
+++ b/src/uvw/check.h
@@ -28,7 +28,7 @@ struct UVW_EXTERN CheckEvent {};
  *
  * To create a `CheckHandle` through a `Loop`, no arguments are required.
  */
-class UVW_EXTERN CheckHandle final : public Handle<CheckHandle, uv_check_t> {
+class UVW_EXTERN CheckHandle final : public Handle<CheckHandle, uv_check_t, CheckEvent> {
     static void startCallback(uv_check_t *handle);
 
 public:

--- a/src/uvw/config.h
+++ b/src/uvw/config.h
@@ -1,12 +1,48 @@
 #ifndef UVW_CONFIG_H
 #define UVW_CONFIG_H
 
+#if defined(BUILDING_UVW_SHARED) && defined(USING_UVW_SHARED)
+#error "Define either BUILDING_UVW_SHARED or USING_UVW_SHARED, not both."
+#endif
 
 #ifndef UVW_AS_LIB
 #define UVW_INLINE inline
+#define UVW_EXTERN /* nothing */
+#else /* UVW_AS_LIB */
+#define UVW_INLINE /* nothing */
+
+#ifdef _WIN32
+/* Windows - set up dll import/export decorators. */
+#if defined(BUILDING_UVW_SHARED)
+/* Building shared library. */
+#define UVW_EXTERN __declspec(dllexport)
+#elif defined(USING_UVW_SHARED)
+/* Using shared library. */
+#define UVW_EXTERN __declspec(dllimport)
 #else
-#define UVW_INLINE
+/* Building static library. */
+#define UVW_EXTERN /* nothing */
+#endif
+#elif __GNUC__ >= 4
+#define UVW_EXTERN __attribute__((visibility("default")))
+#else
+#define UVW_EXTERN /* nothing */
 #endif
 
+#endif /* UVW_AS_LIB */
+
+#if defined(_MSC_VER) && defined(UVW_AS_LIB)
+/*
+ * C4251: 'type' : class 'type1' needs to have dll-interface to be used by clients of class 'type2'
+ */
+#define UVW_MSVC_WARNING_PUSH_DISABLE_DLLINTERFACE() \
+    __pragma(warning(push)) \
+    __pragma(warning(disable: 4251))
+#define UVW_MSVC_WARNING_POP() \
+    __pragma(warning(pop))
+#else
+#define UVW_MSVC_WARNING_PUSH_DISABLE_DLLINTERFACE()
+#define UVW_MSVC_WARNING_POP()
+#endif
 
 #endif

--- a/src/uvw/dns.h
+++ b/src/uvw/dns.h
@@ -71,7 +71,7 @@ struct UVW_EXTERN NameInfoEvent {
  *
  * To create a `GetAddrInfoReq` through a `Loop`, no arguments are required.
  */
-class UVW_EXTERN GetAddrInfoReq final: public Request<GetAddrInfoReq, uv_getaddrinfo_t> {
+class UVW_EXTERN GetAddrInfoReq final: public Request<GetAddrInfoReq, uv_getaddrinfo_t, AddrInfoEvent> {
     static void addrInfoCallback(uv_getaddrinfo_t *req, int status, addrinfo *res);
     void nodeAddrInfo(const char *node, const char *service, addrinfo *hints = nullptr);
     auto nodeAddrInfoSync(const char *node, const char *service, addrinfo *hints = nullptr);
@@ -156,7 +156,7 @@ public:
  *
  * To create a `GetNameInfoReq` through a `Loop`, no arguments are required.
  */
-class UVW_EXTERN GetNameInfoReq final: public Request<GetNameInfoReq, uv_getnameinfo_t> {
+class UVW_EXTERN GetNameInfoReq final: public Request<GetNameInfoReq, uv_getnameinfo_t, NameInfoEvent> {
     static void nameInfoCallback(uv_getnameinfo_t *req, int status, const char *hostname, const char *service);
 
 public:

--- a/src/uvw/dns.h
+++ b/src/uvw/dns.h
@@ -9,6 +9,9 @@
 #include "request.hpp"
 #include "util.h"
 #include "loop.h"
+#include "config.h"
+
+UVW_MSVC_WARNING_PUSH_DISABLE_DLLINTERFACE();
 
 
 namespace uvw {
@@ -19,7 +22,7 @@ namespace uvw {
  *
  * It will be emitted by GetAddrInfoReq according with its functionalities.
  */
-struct AddrInfoEvent {
+struct UVW_EXTERN AddrInfoEvent {
     using Deleter = void(*)(addrinfo *);
 
     AddrInfoEvent(std::unique_ptr<addrinfo, Deleter> addr);
@@ -39,7 +42,7 @@ struct AddrInfoEvent {
  *
  * It will be emitted by GetNameInfoReq according with its functionalities.
  */
-struct NameInfoEvent {
+struct UVW_EXTERN NameInfoEvent {
     NameInfoEvent(const char *host, const char *serv);
 
     /**
@@ -68,7 +71,7 @@ struct NameInfoEvent {
  *
  * To create a `GetAddrInfoReq` through a `Loop`, no arguments are required.
  */
-class GetAddrInfoReq final: public Request<GetAddrInfoReq, uv_getaddrinfo_t> {
+class UVW_EXTERN GetAddrInfoReq final: public Request<GetAddrInfoReq, uv_getaddrinfo_t> {
     static void addrInfoCallback(uv_getaddrinfo_t *req, int status, addrinfo *res);
     void nodeAddrInfo(const char *node, const char *service, addrinfo *hints = nullptr);
     auto nodeAddrInfoSync(const char *node, const char *service, addrinfo *hints = nullptr);
@@ -153,7 +156,7 @@ public:
  *
  * To create a `GetNameInfoReq` through a `Loop`, no arguments are required.
  */
-class GetNameInfoReq final: public Request<GetNameInfoReq, uv_getnameinfo_t> {
+class UVW_EXTERN GetNameInfoReq final: public Request<GetNameInfoReq, uv_getnameinfo_t> {
     static void nameInfoCallback(uv_getnameinfo_t *req, int status, const char *hostname, const char *service);
 
 public:
@@ -232,17 +235,17 @@ public:
 
 // (extern) explicit instantiations
 
-extern template void GetNameInfoReq::nameInfo<IPv4>(std::string ip, unsigned int port, int flags);
-extern template void GetNameInfoReq::nameInfo<IPv6>(std::string ip, unsigned int port, int flags);
+extern template UVW_EXTERN void GetNameInfoReq::nameInfo<IPv4>(std::string ip, unsigned int port, int flags);
+extern template UVW_EXTERN void GetNameInfoReq::nameInfo<IPv6>(std::string ip, unsigned int port, int flags);
 
-extern template void GetNameInfoReq::nameInfo<IPv4>(Addr addr, int flags);
-extern template void GetNameInfoReq::nameInfo<IPv6>(Addr addr, int flags);
+extern template UVW_EXTERN void GetNameInfoReq::nameInfo<IPv4>(Addr addr, int flags);
+extern template UVW_EXTERN void GetNameInfoReq::nameInfo<IPv6>(Addr addr, int flags);
 
-extern template std::pair<bool, std::pair<const char *, const char *>> GetNameInfoReq::nameInfoSync<IPv4>(std::string ip, unsigned int port, int flags);
-extern template std::pair<bool, std::pair<const char *, const char *>> GetNameInfoReq::nameInfoSync<IPv6>(std::string ip, unsigned int port, int flags);
+extern template UVW_EXTERN std::pair<bool, std::pair<const char *, const char *>> GetNameInfoReq::nameInfoSync<IPv4>(std::string ip, unsigned int port, int flags);
+extern template UVW_EXTERN std::pair<bool, std::pair<const char *, const char *>> GetNameInfoReq::nameInfoSync<IPv6>(std::string ip, unsigned int port, int flags);
 
-extern template std::pair<bool, std::pair<const char *, const char *>> GetNameInfoReq::nameInfoSync<IPv4>(Addr addr, int flags);
-extern template std::pair<bool, std::pair<const char *, const char *>> GetNameInfoReq::nameInfoSync<IPv6>(Addr addr, int flags);
+extern template UVW_EXTERN std::pair<bool, std::pair<const char *, const char *>> GetNameInfoReq::nameInfoSync<IPv4>(Addr addr, int flags);
+extern template UVW_EXTERN std::pair<bool, std::pair<const char *, const char *>> GetNameInfoReq::nameInfoSync<IPv6>(Addr addr, int flags);
 
 
 }
@@ -251,5 +254,7 @@ extern template std::pair<bool, std::pair<const char *, const char *>> GetNameIn
 #ifndef UVW_AS_LIB
 #include "dns.cpp"
 #endif
+
+UVW_MSVC_WARNING_POP();
 
 #endif // UVW_DNS_INCLUDE_H

--- a/src/uvw/emitter.h
+++ b/src/uvw/emitter.h
@@ -11,6 +11,9 @@
 #include <memory>
 #include <list>
 #include <uv.h>
+#include "config.h"
+
+UVW_MSVC_WARNING_PUSH_DISABLE_DLLINTERFACE();
 
 
 namespace uvw {
@@ -21,7 +24,7 @@ namespace uvw {
  *
  * Custom wrapper around error constants of `libuv`.
  */
-struct ErrorEvent {
+struct UVW_EXTERN ErrorEvent {
     template<typename U, typename = std::enable_if_t<std::is_integral_v<U>>>
     explicit ErrorEvent(U val) noexcept
         : ec{static_cast<int>(val)}
@@ -190,6 +193,14 @@ protected:
     }
 
 public:
+    Emitter() = default;
+    Emitter(Emitter &&) = default;
+    Emitter & operator=(Emitter &&) = default;
+
+    // These must be deleted because MSVC try to export them with UVW_EXPORT
+    Emitter(const Emitter&) = delete;
+    Emitter& operator=(const Emitter&) = delete;
+
     template<typename E>
     using Listener = typename Handler<E>::Listener;
 
@@ -320,5 +331,7 @@ private:
 #ifndef UVW_AS_LIB
 #include "emitter.cpp"
 #endif
+
+UVW_MSVC_WARNING_POP();
 
 #endif // UVW_EMITTER_INCLUDE_H

--- a/src/uvw/fs.h
+++ b/src/uvw/fs.h
@@ -10,6 +10,9 @@
 #include "request.hpp"
 #include "util.h"
 #include "loop.h"
+#include "config.h"
+
+UVW_MSVC_WARNING_PUSH_DISABLE_DLLINTERFACE();
 
 
 namespace uvw {
@@ -433,7 +436,7 @@ public:
  * [documentation](http://docs.libuv.org/en/v1.x/fs.html)
  * for further details.
  */
-class FileReq final: public FsRequest<FileReq> {
+class UVW_EXTERN FileReq final: public FsRequest<FileReq> {
     static constexpr uv_file BAD_FD = -1;
 
     static void fsOpenCallback(uv_fs_t *req);
@@ -784,7 +787,7 @@ private:
  * [documentation](http://docs.libuv.org/en/v1.x/fs.html)
  * for further details.
  */
-class FsReq final: public FsRequest<FsReq> {
+class UVW_EXTERN FsReq final: public FsRequest<FsReq> {
     static void fsReadlinkCallback(uv_fs_t *req);
     static void fsReaddirCallback(uv_fs_t *req);
 
@@ -1425,7 +1428,7 @@ private:
 
 
 /*! @brief Helper functions. */
-struct FsHelper {
+struct UVW_EXTERN FsHelper {
     /**
      * @brief Gets the OS dependent handle.
      *
@@ -1458,5 +1461,7 @@ struct FsHelper {
 #ifndef UVW_AS_LIB
 #include "fs.cpp"
 #endif
+
+UVW_MSVC_WARNING_POP();
 
 #endif // UVW_FS_INCLUDE_H

--- a/src/uvw/fs.h
+++ b/src/uvw/fs.h
@@ -373,32 +373,35 @@ struct FsEvent<details::UVFsType::READDIR> {
  *
  * Not directly instantiable, should not be used by the users of the library.
  */
-template<typename T>
-class FsRequest: public Request<T, uv_fs_t> {
+template<typename T, typename... Events>
+class FsRequest: public Request<T, uv_fs_t,
+                                 FsEvent<details::UVFsType::STATFS>,
+                                 Events...> {
+    using BaseClass = Request<T, uv_fs_t, FsEvent<details::UVFsType::STATFS>, Events...>;
 protected:
     template<details::UVFsType e>
     static void fsGenericCallback(uv_fs_t *req) {
-        auto ptr = Request<T, uv_fs_t>::reserve(req);
+        auto ptr = BaseClass::reserve(req);
         if(req->result < 0) { ptr->publish(ErrorEvent{req->result}); }
         else { ptr->publish(FsEvent<e>{req->path}); }
     }
 
     template<details::UVFsType e>
     static void fsResultCallback(uv_fs_t *req) {
-        auto ptr = Request<T, uv_fs_t>::reserve(req);
+        auto ptr = BaseClass::reserve(req);
         if(req->result < 0) { ptr->publish(ErrorEvent{req->result}); }
         else { ptr->publish(FsEvent<e>{req->path, static_cast<std::size_t>(req->result)}); }
     }
 
     template<details::UVFsType e>
     static void fsStatCallback(uv_fs_t *req) {
-        auto ptr = Request<T, uv_fs_t>::reserve(req);
+        auto ptr = BaseClass::reserve(req);
         if(req->result < 0) { ptr->publish(ErrorEvent{req->result}); }
         else { ptr->publish(FsEvent<e>{req->path, req->statbuf}); }
     }
 
     static void fsStatfsCallback(uv_fs_t *req) {
-        auto ptr = Request<T, uv_fs_t>::reserve(req);
+        auto ptr = BaseClass::reserve(req);
         if(req->result < 0) { ptr->publish(ErrorEvent{req->result}); }
         else { ptr->publish(FsEvent<Type::STATFS>{req->path, *static_cast<Statfs *>(req->ptr)}); }
     }
@@ -420,7 +423,7 @@ public:
     using Type = details::UVFsType;
     using EntryType = details::UVDirentTypeT;
 
-    using Request<T, uv_fs_t>::Request;
+    using BaseClass::BaseClass;
 };
 
 
@@ -436,7 +439,19 @@ public:
  * [documentation](http://docs.libuv.org/en/v1.x/fs.html)
  * for further details.
  */
-class UVW_EXTERN FileReq final: public FsRequest<FileReq> {
+class UVW_EXTERN FileReq final: public FsRequest<FileReq,
+                                                 FsEvent<details::UVFsType::OPEN>,
+                                                 FsEvent<details::UVFsType::CLOSE>,
+                                                 FsEvent<details::UVFsType::READ>,
+                                                 FsEvent<details::UVFsType::WRITE>,
+                                                 FsEvent<details::UVFsType::FSTAT>,
+                                                 FsEvent<details::UVFsType::FSYNC>,
+                                                 FsEvent<details::UVFsType::FDATASYNC>,
+                                                 FsEvent<details::UVFsType::FTRUNCATE>,
+                                                 FsEvent<details::UVFsType::SENDFILE>,
+                                                 FsEvent<details::UVFsType::FCHMOD>,
+                                                 FsEvent<details::UVFsType::FUTIME>,
+                                                 FsEvent<details::UVFsType::FCHOWN>> {
     static constexpr uv_file BAD_FD = -1;
 
     static void fsOpenCallback(uv_fs_t *req);
@@ -787,7 +802,31 @@ private:
  * [documentation](http://docs.libuv.org/en/v1.x/fs.html)
  * for further details.
  */
-class UVW_EXTERN FsReq final: public FsRequest<FsReq> {
+class UVW_EXTERN FsReq final: public FsRequest<FsReq,
+                                               FsEvent<details::UVFsType::READLINK>,
+                                               FsEvent<details::UVFsType::READDIR>,
+                                               FsEvent<details::UVFsType::UNLINK>,
+                                               FsEvent<details::UVFsType::MKDIR>,
+                                               FsEvent<details::UVFsType::MKDTEMP>,
+                                               FsEvent<details::UVFsType::MKSTEMP>,
+                                               FsEvent<details::UVFsType::LUTIME>,
+                                               FsEvent<details::UVFsType::RMDIR>,
+                                               FsEvent<details::UVFsType::SCANDIR>,
+                                               FsEvent<details::UVFsType::UNKNOWN>,
+                                               FsEvent<details::UVFsType::STAT>,
+                                               FsEvent<details::UVFsType::LSTAT>,
+                                               FsEvent<details::UVFsType::RENAME>,
+                                               FsEvent<details::UVFsType::COPYFILE>,
+                                               FsEvent<details::UVFsType::ACCESS>,
+                                               FsEvent<details::UVFsType::CHMOD>,
+                                               FsEvent<details::UVFsType::UTIME>,
+                                               FsEvent<details::UVFsType::LINK>,
+                                               FsEvent<details::UVFsType::SYMLINK>,
+                                               FsEvent<details::UVFsType::REALPATH>,
+                                               FsEvent<details::UVFsType::CHOWN>,
+                                               FsEvent<details::UVFsType::LCHOWN>,
+                                               FsEvent<details::UVFsType::OPENDIR>,
+                                               FsEvent<details::UVFsType::CLOSEDIR>> {
     static void fsReadlinkCallback(uv_fs_t *req);
     static void fsReaddirCallback(uv_fs_t *req);
 

--- a/src/uvw/fs_event.h
+++ b/src/uvw/fs_event.h
@@ -8,6 +8,9 @@
 #include "handle.hpp"
 #include "util.h"
 #include "loop.h"
+#include "config.h"
+
+UVW_MSVC_WARNING_PUSH_DISABLE_DLLINTERFACE();
 
 
 namespace uvw {
@@ -37,7 +40,7 @@ enum class UVFsEvent: std::underlying_type_t<uv_fs_event> {
  *
  * It will be emitted by FsEventHandle according with its functionalities.
  */
-struct FsEventEvent {
+struct UVW_EXTERN FsEventEvent {
     FsEventEvent(const char * pathname, Flags<details::UVFsEvent> events);
 
     /**
@@ -58,6 +61,7 @@ struct FsEventEvent {
      */
     Flags<details::UVFsEvent> flags;
 };
+template class UVW_EXTERN Flags<details::UVFsEvent>;
 
 
 /**
@@ -73,7 +77,7 @@ struct FsEventEvent {
  * [documentation](http://docs.libuv.org/en/v1.x/fs_event.html)
  * for further details.
  */
-class FsEventHandle final: public Handle<FsEventHandle, uv_fs_event_t> {
+class UVW_EXTERN FsEventHandle final: public Handle<FsEventHandle, uv_fs_event_t> {
     static void startCallback(uv_fs_event_t *handle, const char *filename, int events, int status);
 
 public:
@@ -145,5 +149,7 @@ public:
 #ifndef UVW_AS_LIB
 #include "fs_event.cpp"
 #endif
+
+UVW_MSVC_WARNING_POP();
 
 #endif // UVW_FS_EVENT_INCLUDE_H

--- a/src/uvw/fs_event.h
+++ b/src/uvw/fs_event.h
@@ -77,7 +77,7 @@ template class UVW_EXTERN Flags<details::UVFsEvent>;
  * [documentation](http://docs.libuv.org/en/v1.x/fs_event.html)
  * for further details.
  */
-class UVW_EXTERN FsEventHandle final: public Handle<FsEventHandle, uv_fs_event_t> {
+class UVW_EXTERN FsEventHandle final: public Handle<FsEventHandle, uv_fs_event_t, FsEventEvent> {
     static void startCallback(uv_fs_event_t *handle, const char *filename, int events, int status);
 
 public:

--- a/src/uvw/fs_poll.h
+++ b/src/uvw/fs_poll.h
@@ -8,6 +8,9 @@
 #include "handle.hpp"
 #include "util.h"
 #include "loop.h"
+#include "config.h"
+
+UVW_MSVC_WARNING_PUSH_DISABLE_DLLINTERFACE();
 
 
 namespace uvw {
@@ -18,7 +21,7 @@ namespace uvw {
  *
  * It will be emitted by FsPollHandle according with its functionalities.
  */
-struct FsPollEvent {
+struct UVW_EXTERN FsPollEvent {
     explicit FsPollEvent(Stat previous, Stat current) noexcept;
 
     Stat prev; /*!< The old Stat struct. */
@@ -35,7 +38,7 @@ struct FsPollEvent {
  *
  * To create a `FsPollHandle` through a `Loop`, no arguments are required.
  */
-class FsPollHandle final: public Handle<FsPollHandle, uv_fs_poll_t> {
+class UVW_EXTERN FsPollHandle final: public Handle<FsPollHandle, uv_fs_poll_t> {
     static void startCallback(uv_fs_poll_t *handle, int status, const uv_stat_t *prev, const uv_stat_t *curr);
 
 public:
@@ -79,5 +82,7 @@ public:
 #ifndef UVW_AS_LIB
 #include "fs_poll.cpp"
 #endif
+
+UVW_MSVC_WARNING_POP();
 
 #endif // UVW_FS_POLL_INCLUDE_H

--- a/src/uvw/fs_poll.h
+++ b/src/uvw/fs_poll.h
@@ -38,7 +38,7 @@ struct UVW_EXTERN FsPollEvent {
  *
  * To create a `FsPollHandle` through a `Loop`, no arguments are required.
  */
-class UVW_EXTERN FsPollHandle final: public Handle<FsPollHandle, uv_fs_poll_t> {
+class UVW_EXTERN FsPollHandle final: public Handle<FsPollHandle, uv_fs_poll_t, FsPollEvent> {
     static void startCallback(uv_fs_poll_t *handle, int status, const uv_stat_t *prev, const uv_stat_t *curr);
 
 public:

--- a/src/uvw/handle.hpp
+++ b/src/uvw/handle.hpp
@@ -8,6 +8,9 @@
 #include <uv.h>
 #include "resource.hpp"
 #include "util.h"
+#include "config.h"
+
+UVW_MSVC_WARNING_PUSH_DISABLE_DLLINTERFACE();
 
 
 namespace uvw {
@@ -18,7 +21,7 @@ namespace uvw {
  *
  * It will be emitted by the handles according with their functionalities.
  */
-struct CloseEvent {};
+struct UVW_EXTERN CloseEvent {};
 
 
 /**
@@ -273,5 +276,7 @@ public:
 
 
 }
+
+UVW_MSVC_WARNING_POP();
 
 #endif // UVW_HANDLE_INCLUDE_H

--- a/src/uvw/idle.h
+++ b/src/uvw/idle.h
@@ -5,6 +5,9 @@
 #include <uv.h>
 #include "handle.hpp"
 #include "loop.h"
+#include "config.h"
+
+UVW_MSVC_WARNING_PUSH_DISABLE_DLLINTERFACE();
 
 
 namespace uvw {
@@ -15,7 +18,7 @@ namespace uvw {
  *
  * It will be emitted by IdleHandle according with its functionalities.
  */
-struct IdleEvent {};
+struct UVW_EXTERN IdleEvent {};
 
 
 /**
@@ -34,7 +37,7 @@ struct IdleEvent {};
  *
  * To create an `IdleHandle` through a `Loop`, no arguments are required.
  */
-class IdleHandle final: public Handle<IdleHandle, uv_idle_t> {
+class UVW_EXTERN IdleHandle final: public Handle<IdleHandle, uv_idle_t> {
     static void startCallback(uv_idle_t *handle);
 
 public:
@@ -67,5 +70,7 @@ public:
 #ifndef UVW_AS_LIB
 #include "idle.cpp"
 #endif
+
+UVW_MSVC_WARNING_POP();
 
 #endif // UVW_IDLE_INCLUDE_H

--- a/src/uvw/idle.h
+++ b/src/uvw/idle.h
@@ -37,7 +37,7 @@ struct UVW_EXTERN IdleEvent {};
  *
  * To create an `IdleHandle` through a `Loop`, no arguments are required.
  */
-class UVW_EXTERN IdleHandle final: public Handle<IdleHandle, uv_idle_t> {
+class UVW_EXTERN IdleHandle final: public Handle<IdleHandle, uv_idle_t, IdleEvent> {
     static void startCallback(uv_idle_t *handle);
 
 public:

--- a/src/uvw/lib.h
+++ b/src/uvw/lib.h
@@ -8,6 +8,9 @@
 #include <uv.h>
 #include "loop.h"
 #include "underlying_type.hpp"
+#include "config.h"
+
+UVW_MSVC_WARNING_PUSH_DISABLE_DLLINTERFACE();
 
 
 namespace uvw {
@@ -19,7 +22,7 @@ namespace uvw {
  * `uvw` provides cross platform utilities for loading shared libraries and
  * retrieving symbols from them, by means of the API offered by `libuv`.
  */
-class SharedLib final: public UnderlyingType<SharedLib, uv_lib_t> {
+class UVW_EXTERN SharedLib final: public UnderlyingType<SharedLib, uv_lib_t> {
 public:
     explicit SharedLib(ConstructorAccess ca, std::shared_ptr<Loop> ref, std::string filename) noexcept;
 
@@ -66,5 +69,7 @@ private:
 #ifndef UVW_AS_LIB
 #include "lib.cpp"
 #endif
+
+UVW_MSVC_WARNING_POP();
 
 #endif // UVW_LIB_INCLUDE_H

--- a/src/uvw/loop.h
+++ b/src/uvw/loop.h
@@ -14,6 +14,9 @@
 #include <uv.h>
 #include "emitter.h"
 #include "util.h"
+#include "config.h"
+
+UVW_MSVC_WARNING_PUSH_DISABLE_DLLINTERFACE();
 
 
 namespace uvw {
@@ -45,7 +48,7 @@ enum class UVRunMode: std::underlying_type_t<uv_run_mode> {
  * users walk them as untyped instances.<br/>
  * This can help to end all the pending requests by closing the handles.
  */
-struct BaseHandle {
+struct UVW_EXTERN BaseHandle {
     /**
      * @brief Gets the category of the handle.
      *
@@ -140,7 +143,7 @@ struct BaseHandle {
  * It takes care of polling for I/O and scheduling callbacks to be run based on
  * different sources of events.
  */
-class Loop final: public Emitter<Loop>, public std::enable_shared_from_this<Loop> {
+class UVW_EXTERN Loop final: public Emitter<Loop>, public std::enable_shared_from_this<Loop> {
     using Deleter = void(*)(uv_loop_t *);
 
     template<typename, typename>
@@ -425,9 +428,9 @@ private:
 
 // (extern) explicit instantiations
 
-extern template bool Loop::run<Loop::Mode::DEFAULT>() noexcept;
-extern template bool Loop::run<Loop::Mode::ONCE>() noexcept;
-extern template bool Loop::run<Loop::Mode::NOWAIT>() noexcept;
+extern template UVW_EXTERN bool Loop::run<Loop::Mode::DEFAULT>() noexcept;
+extern template UVW_EXTERN bool Loop::run<Loop::Mode::ONCE>() noexcept;
+extern template UVW_EXTERN bool Loop::run<Loop::Mode::NOWAIT>() noexcept;
 
 
 }
@@ -436,5 +439,7 @@ extern template bool Loop::run<Loop::Mode::NOWAIT>() noexcept;
 #ifndef UVW_AS_LIB
 #include "loop.cpp"
 #endif
+
+UVW_MSVC_WARNING_POP();
 
 #endif // UVW_LOOP_INCLUDE_H

--- a/src/uvw/loop.h
+++ b/src/uvw/loop.h
@@ -143,10 +143,10 @@ struct UVW_EXTERN BaseHandle {
  * It takes care of polling for I/O and scheduling callbacks to be run based on
  * different sources of events.
  */
-class UVW_EXTERN Loop final: public Emitter<Loop>, public std::enable_shared_from_this<Loop> {
+class UVW_EXTERN Loop final: public Emitter<Loop, ErrorEvent>, public std::enable_shared_from_this<Loop> {
     using Deleter = void(*)(uv_loop_t *);
 
-    template<typename, typename>
+    template<typename, typename, typename...>
     friend class Resource;
 
     Loop(std::unique_ptr<uv_loop_t, Deleter> ptr) noexcept;

--- a/src/uvw/pipe.h
+++ b/src/uvw/pipe.h
@@ -10,6 +10,9 @@
 #include "stream.h"
 #include "util.h"
 #include "loop.h"
+#include "config.h"
+
+UVW_MSVC_WARNING_PUSH_DISABLE_DLLINTERFACE();
 
 
 namespace uvw {
@@ -38,7 +41,7 @@ enum class UVChmodFlags: std::underlying_type_t<uv_poll_event> {
  * * An optional boolean value that indicates if this pipe will be used for
  * handle passing between processes.
  */
-class PipeHandle final: public StreamHandle<PipeHandle, uv_pipe_t> {
+class UVW_EXTERN PipeHandle final: public StreamHandle<PipeHandle, uv_pipe_t> {
 public:
     using Chmod = details::UVChmodFlags;
 
@@ -163,5 +166,7 @@ private:
 #ifndef UVW_AS_LIB
 #include "pipe.cpp"
 #endif
+
+UVW_MSVC_WARNING_POP();
 
 #endif // UVW_PIPE_INCLUDE_H

--- a/src/uvw/pipe.h
+++ b/src/uvw/pipe.h
@@ -41,7 +41,7 @@ enum class UVChmodFlags: std::underlying_type_t<uv_poll_event> {
  * * An optional boolean value that indicates if this pipe will be used for
  * handle passing between processes.
  */
-class UVW_EXTERN PipeHandle final: public StreamHandle<PipeHandle, uv_pipe_t> {
+class UVW_EXTERN PipeHandle final: public StreamHandle<PipeHandle, uv_pipe_t, ConnectEvent> {
 public:
     using Chmod = details::UVChmodFlags;
 

--- a/src/uvw/poll.h
+++ b/src/uvw/poll.h
@@ -7,6 +7,9 @@
 #include <uv.h>
 #include "handle.hpp"
 #include "util.h"
+#include "config.h"
+
+UVW_MSVC_WARNING_PUSH_DISABLE_DLLINTERFACE();
 
 
 namespace uvw {
@@ -31,7 +34,7 @@ enum class UVPollEvent: std::underlying_type_t<uv_poll_event> {
  *
  * It will be emitted by PollHandle according with its functionalities.
  */
-struct PollEvent {
+struct UVW_EXTERN PollEvent {
     explicit PollEvent(Flags<details::UVPollEvent> events) noexcept;
 
     /**
@@ -46,6 +49,7 @@ struct PollEvent {
      */
     Flags<details::UVPollEvent> flags;
 };
+template class UVW_EXTERN Flags<details::UVPollEvent>;
 
 
 /**
@@ -64,7 +68,7 @@ struct PollEvent {
  * [documentation](http://docs.libuv.org/en/v1.x/poll.html)
  * for further details.
  */
-class PollHandle final: public Handle<PollHandle, uv_poll_t> {
+class UVW_EXTERN PollHandle final: public Handle<PollHandle, uv_poll_t> {
     static void startCallback(uv_poll_t *handle, int status, int events);
 
 public:
@@ -141,5 +145,7 @@ private:
 #ifndef UVW_AS_LIB
 #include "poll.cpp"
 #endif
+
+UVW_MSVC_WARNING_POP();
 
 #endif // UVW_POLL_INCLUDE_H

--- a/src/uvw/poll.h
+++ b/src/uvw/poll.h
@@ -68,7 +68,7 @@ template class UVW_EXTERN Flags<details::UVPollEvent>;
  * [documentation](http://docs.libuv.org/en/v1.x/poll.html)
  * for further details.
  */
-class UVW_EXTERN PollHandle final: public Handle<PollHandle, uv_poll_t> {
+class UVW_EXTERN PollHandle final: public Handle<PollHandle, uv_poll_t, PollEvent> {
     static void startCallback(uv_poll_t *handle, int status, int events);
 
 public:

--- a/src/uvw/prepare.h
+++ b/src/uvw/prepare.h
@@ -5,6 +5,9 @@
 #include <uv.h>
 #include "handle.hpp"
 #include "loop.h"
+#include "config.h"
+
+UVW_MSVC_WARNING_PUSH_DISABLE_DLLINTERFACE();
 
 
 namespace uvw {
@@ -15,7 +18,7 @@ namespace uvw {
  *
  * It will be emitted by PrepareHandle according with its functionalities.
  */
-struct PrepareEvent {};
+struct UVW_EXTERN PrepareEvent {};
 
 
 /**
@@ -26,7 +29,7 @@ struct PrepareEvent {};
  *
  * To create a `PrepareHandle` through a `Loop`, no arguments are required.
  */
-class PrepareHandle final: public Handle<PrepareHandle, uv_prepare_t> {
+class UVW_EXTERN PrepareHandle final: public Handle<PrepareHandle, uv_prepare_t> {
     static void startCallback(uv_prepare_t *handle);
 
 public:
@@ -61,5 +64,7 @@ public:
 #ifndef UVW_AS_LIB
 #include "prepare.cpp"
 #endif
+
+UVW_MSVC_WARNING_POP();
 
 #endif // UVW_PREPARE_INCLUDE_H

--- a/src/uvw/prepare.h
+++ b/src/uvw/prepare.h
@@ -29,7 +29,7 @@ struct UVW_EXTERN PrepareEvent {};
  *
  * To create a `PrepareHandle` through a `Loop`, no arguments are required.
  */
-class UVW_EXTERN PrepareHandle final: public Handle<PrepareHandle, uv_prepare_t> {
+class UVW_EXTERN PrepareHandle final: public Handle<PrepareHandle, uv_prepare_t, PrepareEvent> {
     static void startCallback(uv_prepare_t *handle);
 
 public:

--- a/src/uvw/process.h
+++ b/src/uvw/process.h
@@ -11,6 +11,9 @@
 #include "stream.h"
 #include "util.h"
 #include "loop.h"
+#include "config.h"
+
+UVW_MSVC_WARNING_PUSH_DISABLE_DLLINTERFACE();
 
 
 namespace uvw {
@@ -49,7 +52,7 @@ enum class UVStdIOFlags: std::underlying_type_t<uv_stdio_flags> {
  *
  * It will be emitted by ProcessHandle according with its functionalities.
  */
-struct ExitEvent {
+struct UVW_EXTERN ExitEvent {
     explicit ExitEvent(int64_t code, int sig) noexcept;
 
     int64_t status; /*!< The exit status. */
@@ -62,7 +65,7 @@ struct ExitEvent {
  * Process handles will spawn a new process and allow the user to control it and
  * establish communication channels with it using streams.
  */
-class ProcessHandle final: public Handle<ProcessHandle, uv_process_t> {
+class UVW_EXTERN ProcessHandle final: public Handle<ProcessHandle, uv_process_t> {
     static void exitCallback(uv_process_t *handle, int64_t exitStatus, int termSignal);
 
 public:
@@ -242,6 +245,7 @@ private:
     Uid poUid;
     Gid poGid;
 };
+template class UVW_EXTERN Flags<ProcessHandle::Process>;
 
 
 }
@@ -250,5 +254,7 @@ private:
 #ifndef UVW_AS_LIB
 #include "process.cpp"
 #endif
+
+UVW_MSVC_WARNING_POP();
 
 #endif // UVW_PROCESS_INCLUDE_H

--- a/src/uvw/process.h
+++ b/src/uvw/process.h
@@ -65,7 +65,7 @@ struct UVW_EXTERN ExitEvent {
  * Process handles will spawn a new process and allow the user to control it and
  * establish communication channels with it using streams.
  */
-class UVW_EXTERN ProcessHandle final: public Handle<ProcessHandle, uv_process_t> {
+class UVW_EXTERN ProcessHandle final: public Handle<ProcessHandle, uv_process_t, ExitEvent> {
     static void exitCallback(uv_process_t *handle, int64_t exitStatus, int termSignal);
 
 public:
@@ -185,8 +185,8 @@ public:
      * @param flags A valid set of flags.
      * @return A reference to this process handle.
      */
-    template<typename T, typename U>
-    ProcessHandle & stdio(StreamHandle<T, U> &stream, Flags<StdIO> flags) {
+    template<typename T, typename U, typename... Events>
+    ProcessHandle & stdio(StreamHandle<T, U, Events...> &stream, Flags<StdIO> flags) {
         uv_stdio_container_t container;
         Flags<StdIO>::Type fgs = flags;
         container.flags = static_cast<uv_stdio_flags>(fgs);

--- a/src/uvw/request.hpp
+++ b/src/uvw/request.hpp
@@ -7,6 +7,9 @@
 #include <memory>
 #include <uv.h>
 #include "resource.hpp"
+#include "config.h"
+
+UVW_MSVC_WARNING_PUSH_DISABLE_DLLINTERFACE();
 
 
 namespace uvw {
@@ -71,5 +74,7 @@ public:
 
 
 }
+
+UVW_MSVC_WARNING_POP();
 
 #endif // UVW_REQUEST_INCLUDE_H

--- a/src/uvw/request.hpp
+++ b/src/uvw/request.hpp
@@ -15,8 +15,8 @@ UVW_MSVC_WARNING_PUSH_DISABLE_DLLINTERFACE();
 namespace uvw {
 
 
-template<typename T, typename U>
-class Request: public Resource<T, U> {
+template<typename T, typename U, typename... Events>
+class Request: public Resource<T, U, ErrorEvent, Events...> {
 protected:
     static auto reserve(U *req) {
         auto ptr = static_cast<T*>(req->data)->shared_from_this();
@@ -38,13 +38,13 @@ protected:
             this->leak();
         } else {
             auto err = std::forward<F>(f)(std::forward<Args>(args)...);
-            if(err) { Emitter<T>::publish(ErrorEvent{err}); }
+            if(err) { Emitter<T, ErrorEvent, Events...>::publish(ErrorEvent{err}); }
             else { this->leak(); }
         }
     }
 
 public:
-    using Resource<T, U>::Resource;
+    using Resource<T, U, ErrorEvent, Events...>::Resource;
 
     /**
     * @brief Cancels a pending request.

--- a/src/uvw/resource.hpp
+++ b/src/uvw/resource.hpp
@@ -19,8 +19,8 @@ namespace uvw {
  *
  * This is the base class for handles and requests.
  */
-template<typename T, typename U>
-class Resource: public UnderlyingType<T, U>, public Emitter<T>, public std::enable_shared_from_this<T> {
+template<typename T, typename U, typename... Events>
+class Resource: public UnderlyingType<T, U>, public Emitter<T, Events...>, public std::enable_shared_from_this<T> {
 protected:
     using ConstructorAccess = typename UnderlyingType<T, U>::ConstructorAccess;
 
@@ -43,7 +43,7 @@ protected:
 public:
     explicit Resource(ConstructorAccess ca, std::shared_ptr<Loop> ref)
         : UnderlyingType<T, U>{ca, std::move(ref)},
-          Emitter<T>{},
+          Emitter<T, Events...>{},
           std::enable_shared_from_this<T>{}
     {
         this->get()->data = this;

--- a/src/uvw/resource.hpp
+++ b/src/uvw/resource.hpp
@@ -6,6 +6,9 @@
 #include <utility>
 #include "emitter.h"
 #include "underlying_type.hpp"
+#include "config.h"
+
+UVW_MSVC_WARNING_PUSH_DISABLE_DLLINTERFACE();
 
 
 namespace uvw {
@@ -69,5 +72,7 @@ private:
 };
 
 }
+
+UVW_MSVC_WARNING_POP();
 
 #endif // UVW_RESOURCE_INCLUDE_H

--- a/src/uvw/signal.h
+++ b/src/uvw/signal.h
@@ -5,6 +5,9 @@
 #include <uv.h>
 #include "handle.hpp"
 #include "loop.h"
+#include "config.h"
+
+UVW_MSVC_WARNING_PUSH_DISABLE_DLLINTERFACE();
 
 
 namespace uvw {
@@ -15,7 +18,7 @@ namespace uvw {
  *
  * It will be emitted by SignalHandle according with its functionalities.
  */
-struct SignalEvent {
+struct UVW_EXTERN SignalEvent {
     explicit SignalEvent(int sig) noexcept;
 
     int signum; /*!< The signal being monitored by this handle. */
@@ -35,7 +38,7 @@ struct SignalEvent {
  * [documentation](http://docs.libuv.org/en/v1.x/signal.html)
  * for further details.
  */
-class SignalHandle final: public Handle<SignalHandle, uv_signal_t> {
+class UVW_EXTERN SignalHandle final: public Handle<SignalHandle, uv_signal_t> {
     static void startCallback(uv_signal_t *handle, int signum);
 
 public:
@@ -85,5 +88,7 @@ public:
 #ifndef UVW_AS_LIB
 #include "signal.cpp"
 #endif
+
+UVW_MSVC_WARNING_POP();
 
 #endif // UVW_SIGNAL_INCLUDE_H

--- a/src/uvw/signal.h
+++ b/src/uvw/signal.h
@@ -38,7 +38,7 @@ struct UVW_EXTERN SignalEvent {
  * [documentation](http://docs.libuv.org/en/v1.x/signal.html)
  * for further details.
  */
-class UVW_EXTERN SignalHandle final: public Handle<SignalHandle, uv_signal_t> {
+class UVW_EXTERN SignalHandle final: public Handle<SignalHandle, uv_signal_t, SignalEvent> {
     static void startCallback(uv_signal_t *handle, int signum);
 
 public:

--- a/src/uvw/stream.h
+++ b/src/uvw/stream.h
@@ -11,6 +11,9 @@
 #include "request.hpp"
 #include "handle.hpp"
 #include "loop.h"
+#include "config.h"
+
+UVW_MSVC_WARNING_PUSH_DISABLE_DLLINTERFACE();
 
 
 namespace uvw {
@@ -21,7 +24,7 @@ namespace uvw {
  *
  * It will be emitted by StreamHandle according with its functionalities.
  */
-struct ConnectEvent {};
+struct UVW_EXTERN ConnectEvent {};
 
 
 /**
@@ -29,7 +32,7 @@ struct ConnectEvent {};
  *
  * It will be emitted by StreamHandle according with its functionalities.
  */
-struct EndEvent {};
+struct UVW_EXTERN EndEvent {};
 
 
 /**
@@ -37,7 +40,7 @@ struct EndEvent {};
  *
  * It will be emitted by StreamHandle according with its functionalities.
  */
-struct ListenEvent {};
+struct UVW_EXTERN ListenEvent {};
 
 
 /**
@@ -45,7 +48,7 @@ struct ListenEvent {};
  *
  * It will be emitted by StreamHandle according with its functionalities.
  */
-struct ShutdownEvent {};
+struct UVW_EXTERN ShutdownEvent {};
 
 
 /**
@@ -53,7 +56,7 @@ struct ShutdownEvent {};
  *
  * It will be emitted by StreamHandle according with its functionalities.
  */
-struct WriteEvent {};
+struct UVW_EXTERN WriteEvent {};
 
 
 /**
@@ -61,7 +64,7 @@ struct WriteEvent {};
  *
  * It will be emitted by StreamHandle according with its functionalities.
  */
-struct DataEvent {
+struct UVW_EXTERN DataEvent {
     explicit DataEvent(std::unique_ptr<char[]> buf, std::size_t len) noexcept;
 
     std::unique_ptr<char[]> data; /*!< A bunch of data read on the stream. */
@@ -82,7 +85,7 @@ struct ConnectReq final: public Request<ConnectReq, uv_connect_t> {
 };
 
 
-struct ShutdownReq final: public Request<ShutdownReq, uv_shutdown_t> {
+struct UVW_EXTERN ShutdownReq final: public Request<ShutdownReq, uv_shutdown_t> {
     using Request::Request;
 
     void shutdown(uv_stream_t *handle);
@@ -446,5 +449,7 @@ public:
 #ifndef UVW_AS_LIB
 #include "stream.cpp"
 #endif
+
+UVW_MSVC_WARNING_POP();
 
 #endif // UVW_STREAM_INCLUDE_H

--- a/src/uvw/tcp.h
+++ b/src/uvw/tcp.h
@@ -46,7 +46,7 @@ enum class UVTCPFlags: std::underlying_type_t<uv_tcp_flags> {
  * [documentation](http://docs.libuv.org/en/v1.x/tcp.html#c.uv_tcp_init_ex)
  * for further details.
  */
-class UVW_EXTERN TCPHandle final: public StreamHandle<TCPHandle, uv_tcp_t> {
+class UVW_EXTERN TCPHandle final: public StreamHandle<TCPHandle, uv_tcp_t, ConnectEvent> {
 public:
     using Time = std::chrono::duration<unsigned int>;
     using Bind = details::UVTCPFlags;

--- a/src/uvw/tcp.h
+++ b/src/uvw/tcp.h
@@ -11,6 +11,9 @@
 #include "request.hpp"
 #include "stream.h"
 #include "util.h"
+#include "config.h"
+
+UVW_MSVC_WARNING_PUSH_DISABLE_DLLINTERFACE();
 
 
 namespace uvw {
@@ -43,7 +46,7 @@ enum class UVTCPFlags: std::underlying_type_t<uv_tcp_flags> {
  * [documentation](http://docs.libuv.org/en/v1.x/tcp.html#c.uv_tcp_init_ex)
  * for further details.
  */
-class TCPHandle final: public StreamHandle<TCPHandle, uv_tcp_t> {
+class UVW_EXTERN TCPHandle final: public StreamHandle<TCPHandle, uv_tcp_t> {
 public:
     using Time = std::chrono::duration<unsigned int>;
     using Bind = details::UVTCPFlags;
@@ -232,23 +235,23 @@ private:
 
 // (extern) explicit instantiations
 
-extern template void TCPHandle::bind<IPv4>(std::string, unsigned int, Flags<Bind>);
-extern template void TCPHandle::bind<IPv6>(std::string, unsigned int, Flags<Bind>);
+extern template UVW_EXTERN void TCPHandle::bind<IPv4>(std::string, unsigned int, Flags<Bind>);
+extern template UVW_EXTERN void TCPHandle::bind<IPv6>(std::string, unsigned int, Flags<Bind>);
 
-extern template void TCPHandle::bind<IPv4>(Addr, Flags<Bind>);
-extern template void TCPHandle::bind<IPv6>(Addr, Flags<Bind>);
+extern template UVW_EXTERN void TCPHandle::bind<IPv4>(Addr, Flags<Bind>);
+extern template UVW_EXTERN void TCPHandle::bind<IPv6>(Addr, Flags<Bind>);
 
-extern template Addr TCPHandle::sock<IPv4>() const noexcept;
-extern template Addr TCPHandle::sock<IPv6>() const noexcept;
+extern template UVW_EXTERN Addr TCPHandle::sock<IPv4>() const noexcept;
+extern template UVW_EXTERN Addr TCPHandle::sock<IPv6>() const noexcept;
 
-extern template Addr TCPHandle::peer<IPv4>() const noexcept;
-extern template Addr TCPHandle::peer<IPv6>() const noexcept;
+extern template UVW_EXTERN Addr TCPHandle::peer<IPv4>() const noexcept;
+extern template UVW_EXTERN Addr TCPHandle::peer<IPv6>() const noexcept;
 
-extern template void TCPHandle::connect<IPv4>(std::string, unsigned int);
-extern template void TCPHandle::connect<IPv6>(std::string, unsigned int);
+extern template UVW_EXTERN void TCPHandle::connect<IPv4>(std::string, unsigned int);
+extern template UVW_EXTERN void TCPHandle::connect<IPv6>(std::string, unsigned int);
 
-extern template void TCPHandle::connect<IPv4>(Addr addr);
-extern template void TCPHandle::connect<IPv6>(Addr addr);
+extern template UVW_EXTERN void TCPHandle::connect<IPv4>(Addr addr);
+extern template UVW_EXTERN void TCPHandle::connect<IPv6>(Addr addr);
 
 
 }
@@ -257,5 +260,7 @@ extern template void TCPHandle::connect<IPv6>(Addr addr);
 #ifndef UVW_AS_LIB
 #include "tcp.cpp"
 #endif
+
+UVW_MSVC_WARNING_POP();
 
 #endif // UVW_TCP_INCLUDE_H

--- a/src/uvw/thread.h
+++ b/src/uvw/thread.h
@@ -10,6 +10,9 @@
 #include <uv.h>
 #include "loop.h"
 #include "underlying_type.hpp"
+#include "config.h"
+
+UVW_MSVC_WARNING_PUSH_DISABLE_DLLINTERFACE();
 
 
 namespace uvw {
@@ -46,7 +49,7 @@ class Barrier;
  * that it can be assigned to an `std::function<void(std::shared_ptr<void>)>`.
  * * An optional payload the type of which is `std::shared_ptr<void>`.
  */
-class Thread final: public UnderlyingType<Thread, uv_thread_t> {
+class UVW_EXTERN Thread final: public UnderlyingType<Thread, uv_thread_t> {
     using InternalTask = std::function<void(std::shared_ptr<void>)>;
 
     static void createCallback(void *arg);
@@ -114,7 +117,7 @@ private:
  * seen as a global variable that is only visible to a particular thread and not
  * the whole program.
  */
-class ThreadLocalStorage final: public UnderlyingType<ThreadLocalStorage, uv_key_t> {
+class UVW_EXTERN ThreadLocalStorage final: public UnderlyingType<ThreadLocalStorage, uv_key_t> {
 public:
     explicit ThreadLocalStorage(ConstructorAccess ca, std::shared_ptr<Loop> ref) noexcept;
 
@@ -148,7 +151,7 @@ public:
  * Runs a function once and only once. Concurrent calls to `once` will block all
  * callers except one (it’s unspecified which one).
  */
-class Once final: public UnderlyingType<Once, uv_once_t> {
+class UVW_EXTERN Once final: public UnderlyingType<Once, uv_once_t> {
     static uv_once_t* guard() noexcept;
 
 public:
@@ -181,7 +184,7 @@ public:
  * * An option boolean that specifies if the mutex is a recursive one. The
  * default value is false, the mutex isn't recursive.
  */
-class Mutex final: public UnderlyingType<Mutex, uv_mutex_t> {
+class UVW_EXTERN Mutex final: public UnderlyingType<Mutex, uv_mutex_t> {
     friend class Condition;
 
 public:
@@ -210,7 +213,7 @@ public:
 /**
  * @brief The RWLock wrapper.
  */
-class RWLock final: public UnderlyingType<RWLock, uv_rwlock_t> {
+class UVW_EXTERN RWLock final: public UnderlyingType<RWLock, uv_rwlock_t> {
 public:
     explicit RWLock(ConstructorAccess ca, std::shared_ptr<Loop> ref) noexcept;
 
@@ -257,7 +260,7 @@ public:
  *
  * * An unsigned integer that specifies the initial value for the semaphore.
  */
-class Semaphore final: public UnderlyingType<Semaphore, uv_sem_t> {
+class UVW_EXTERN Semaphore final: public UnderlyingType<Semaphore, uv_sem_t> {
 public:
     explicit Semaphore(ConstructorAccess ca, std::shared_ptr<Loop> ref, unsigned int value) noexcept;
 
@@ -284,7 +287,7 @@ public:
 /**
  * @brief The Condition wrapper.
  */
-class Condition final: public UnderlyingType<Condition, uv_cond_t> {
+class UVW_EXTERN Condition final: public UnderlyingType<Condition, uv_cond_t> {
 public:
     explicit Condition(ConstructorAccess ca, std::shared_ptr<Loop> ref) noexcept;
 
@@ -344,7 +347,7 @@ public:
  * `wait` before any of them successfully return from the call. The value
  * specified must be greater than zero.
  */
-class Barrier final: public UnderlyingType<Barrier, uv_barrier_t> {
+class UVW_EXTERN Barrier final: public UnderlyingType<Barrier, uv_barrier_t> {
 public:
     explicit Barrier(ConstructorAccess ca, std::shared_ptr<Loop> ref, unsigned int count) noexcept;
 
@@ -364,5 +367,7 @@ public:
 #ifndef UVW_AS_LIB
 #include "thread.cpp"
 #endif
+
+UVW_MSVC_WARNING_POP();
 
 #endif // UVW_THREAD_INCLUDE_H

--- a/src/uvw/timer.h
+++ b/src/uvw/timer.h
@@ -6,6 +6,9 @@
 #include <uv.h>
 #include "handle.hpp"
 #include "loop.h"
+#include "config.h"
+
+UVW_MSVC_WARNING_PUSH_DISABLE_DLLINTERFACE();
 
 
 namespace uvw {
@@ -16,7 +19,7 @@ namespace uvw {
  *
  * It will be emitted by TimerHandle according with its functionalities.
  */
-struct TimerEvent {};
+struct UVW_EXTERN TimerEvent {};
 
 
 /**
@@ -26,7 +29,7 @@ struct TimerEvent {};
  *
  * To create a `TimerHandle` through a `Loop`, no arguments are required.
  */
-class TimerHandle final: public Handle<TimerHandle, uv_timer_t> {
+class UVW_EXTERN TimerHandle final: public Handle<TimerHandle, uv_timer_t> {
     static void startCallback(uv_timer_t *handle);
 
 public:
@@ -103,5 +106,7 @@ public:
 #ifndef UVW_AS_LIB
 #include "timer.cpp"
 #endif
+
+UVW_MSVC_WARNING_POP();
 
 #endif // UVW_TIMER_INCLUDE_H

--- a/src/uvw/timer.h
+++ b/src/uvw/timer.h
@@ -29,7 +29,7 @@ struct UVW_EXTERN TimerEvent {};
  *
  * To create a `TimerHandle` through a `Loop`, no arguments are required.
  */
-class UVW_EXTERN TimerHandle final: public Handle<TimerHandle, uv_timer_t> {
+class UVW_EXTERN TimerHandle final: public Handle<TimerHandle, uv_timer_t, TimerEvent> {
     static void startCallback(uv_timer_t *handle);
 
 public:

--- a/src/uvw/tty.h
+++ b/src/uvw/tty.h
@@ -7,6 +7,9 @@
 #include <uv.h>
 #include "stream.h"
 #include "util.h"
+#include "config.h"
+
+UVW_MSVC_WARNING_PUSH_DISABLE_DLLINTERFACE();
 
 
 namespace uvw {
@@ -15,7 +18,7 @@ namespace uvw {
 namespace details {
 
 
-struct ResetModeMemo {
+struct UVW_EXTERN ResetModeMemo {
     ~ResetModeMemo();
 };
 
@@ -54,7 +57,7 @@ enum class UVTTYVTermStateT: std::underlying_type_t<uv_tty_vtermstate_t> {
  * [documentation](http://docs.libuv.org/en/v1.x/tty.html#c.uv_tty_init)
  * for further details.
  */
-class TTYHandle final: public StreamHandle<TTYHandle, uv_tty_t> {
+class UVW_EXTERN TTYHandle final: public StreamHandle<TTYHandle, uv_tty_t> {
     static std::shared_ptr<details::ResetModeMemo> resetModeMemo();
 
 public:
@@ -151,5 +154,7 @@ private:
 #ifndef UVW_AS_LIB
 #include "tty.cpp"
 #endif
+
+UVW_MSVC_WARNING_POP();
 
 #endif // UVW_TTY_INCLUDE_H

--- a/src/uvw/udp.cpp
+++ b/src/uvw/udp.cpp
@@ -14,7 +14,7 @@ UVW_INLINE UDPDataEvent::UDPDataEvent(Addr sndr, std::unique_ptr<const char[]> b
 
 
 UVW_INLINE details::SendReq::SendReq(ConstructorAccess ca, std::shared_ptr<Loop> loop, std::unique_ptr<char[], Deleter> dt, unsigned int len)
-    : Request<SendReq, uv_udp_send_t>{ca, std::move(loop)},
+    : Request<SendReq, uv_udp_send_t, SendEvent>{ca, std::move(loop)},
       data{std::move(dt)},
       buf{uv_buf_init(data.get(), len)}
 {}

--- a/src/uvw/udp.h
+++ b/src/uvw/udp.h
@@ -60,7 +60,7 @@ enum class UVMembership: std::underlying_type_t<uv_membership> {
 };
 
 
-class UVW_EXTERN SendReq final: public Request<SendReq, uv_udp_send_t> {
+class UVW_EXTERN SendReq final: public Request<SendReq, uv_udp_send_t, SendEvent> {
 public:
     using Deleter = void(*)(char *);
 
@@ -93,7 +93,7 @@ private:
  * [documentation](http://docs.libuv.org/en/v1.x/udp.html#c.uv_udp_init_ex)
  * for further details.
  */
-class UVW_EXTERN UDPHandle final: public Handle<UDPHandle, uv_udp_t> {
+class UVW_EXTERN UDPHandle final: public Handle<UDPHandle, uv_udp_t, UDPDataEvent, SendEvent> {
     template<typename I>
     static void recvCallback(uv_udp_t *handle, ssize_t nread, const uv_buf_t *buf, const sockaddr *addr, unsigned flags) {
         const typename details::IpTraits<I>::Type *aptr = reinterpret_cast<const typename details::IpTraits<I>::Type *>(addr);

--- a/src/uvw/udp.h
+++ b/src/uvw/udp.h
@@ -11,6 +11,9 @@
 #include "request.hpp"
 #include "handle.hpp"
 #include "util.h"
+#include "config.h"
+
+UVW_MSVC_WARNING_PUSH_DISABLE_DLLINTERFACE();
 
 
 namespace uvw {
@@ -21,7 +24,7 @@ namespace uvw {
  *
  * It will be emitted by UDPHandle according with its functionalities.
  */
-struct SendEvent {};
+struct UVW_EXTERN SendEvent {};
 
 
 /**
@@ -29,7 +32,7 @@ struct SendEvent {};
  *
  * It will be emitted by UDPHandle according with its functionalities.
  */
-struct UDPDataEvent {
+struct UVW_EXTERN UDPDataEvent {
     explicit UDPDataEvent(Addr sndr, std::unique_ptr<const char[]> buf, std::size_t len, bool part) noexcept;
 
     std::unique_ptr<const char[]> data; /*!< A bunch of data read on the stream. */
@@ -57,7 +60,7 @@ enum class UVMembership: std::underlying_type_t<uv_membership> {
 };
 
 
-class SendReq final: public Request<SendReq, uv_udp_send_t> {
+class UVW_EXTERN SendReq final: public Request<SendReq, uv_udp_send_t> {
 public:
     using Deleter = void(*)(char *);
 
@@ -90,7 +93,7 @@ private:
  * [documentation](http://docs.libuv.org/en/v1.x/udp.html#c.uv_udp_init_ex)
  * for further details.
  */
-class UDPHandle final: public Handle<UDPHandle, uv_udp_t> {
+class UVW_EXTERN UDPHandle final: public Handle<UDPHandle, uv_udp_t> {
     template<typename I>
     static void recvCallback(uv_udp_t *handle, ssize_t nread, const uv_buf_t *buf, const sockaddr *addr, unsigned flags) {
         const typename details::IpTraits<I>::Type *aptr = reinterpret_cast<const typename details::IpTraits<I>::Type *>(addr);
@@ -578,62 +581,62 @@ private:
 
 // (extern) explicit instantiations
 
-extern template void UDPHandle::connect<IPv4>(std::string, unsigned int);
-extern template void UDPHandle::connect<IPv6>(std::string, unsigned int);
+extern template UVW_EXTERN void UDPHandle::connect<IPv4>(std::string, unsigned int);
+extern template UVW_EXTERN void UDPHandle::connect<IPv6>(std::string, unsigned int);
 
-extern template void UDPHandle::connect<IPv4>(Addr);
-extern template void UDPHandle::connect<IPv6>(Addr);
+extern template UVW_EXTERN void UDPHandle::connect<IPv4>(Addr);
+extern template UVW_EXTERN void UDPHandle::connect<IPv6>(Addr);
 
-extern template Addr UDPHandle::peer<IPv4>() const noexcept;
-extern template Addr UDPHandle::peer<IPv6>() const noexcept;
+extern template UVW_EXTERN Addr UDPHandle::peer<IPv4>() const noexcept;
+extern template UVW_EXTERN Addr UDPHandle::peer<IPv6>() const noexcept;
 
-extern template void UDPHandle::bind<IPv4>(std::string, unsigned int, Flags<Bind>);
-extern template void UDPHandle::bind<IPv6>(std::string, unsigned int, Flags<Bind>);
+extern template UVW_EXTERN void UDPHandle::bind<IPv4>(std::string, unsigned int, Flags<Bind>);
+extern template UVW_EXTERN void UDPHandle::bind<IPv6>(std::string, unsigned int, Flags<Bind>);
 
-extern template void UDPHandle::bind<IPv4>(Addr, Flags<Bind>);
-extern template void UDPHandle::bind<IPv6>(Addr, Flags<Bind>);
+extern template UVW_EXTERN void UDPHandle::bind<IPv4>(Addr, Flags<Bind>);
+extern template UVW_EXTERN void UDPHandle::bind<IPv6>(Addr, Flags<Bind>);
 
-extern template Addr UDPHandle::sock<IPv4>() const noexcept;
-extern template Addr UDPHandle::sock<IPv6>() const noexcept;
+extern template UVW_EXTERN Addr UDPHandle::sock<IPv4>() const noexcept;
+extern template UVW_EXTERN Addr UDPHandle::sock<IPv6>() const noexcept;
 
-extern template bool UDPHandle::multicastMembership<IPv4>(std::string, std::string, Membership);
-extern template bool UDPHandle::multicastMembership<IPv6>(std::string, std::string, Membership);
+extern template UVW_EXTERN bool UDPHandle::multicastMembership<IPv4>(std::string, std::string, Membership);
+extern template UVW_EXTERN bool UDPHandle::multicastMembership<IPv6>(std::string, std::string, Membership);
 
-extern template bool UDPHandle::multicastInterface<IPv4>(std::string);
-extern template bool UDPHandle::multicastInterface<IPv6>(std::string);
+extern template UVW_EXTERN bool UDPHandle::multicastInterface<IPv4>(std::string);
+extern template UVW_EXTERN bool UDPHandle::multicastInterface<IPv6>(std::string);
 
-extern template void UDPHandle::send<IPv4>(std::string, unsigned int, std::unique_ptr<char[]>, unsigned int);
-extern template void UDPHandle::send<IPv6>(std::string, unsigned int, std::unique_ptr<char[]>, unsigned int);
+extern template UVW_EXTERN void UDPHandle::send<IPv4>(std::string, unsigned int, std::unique_ptr<char[]>, unsigned int);
+extern template UVW_EXTERN void UDPHandle::send<IPv6>(std::string, unsigned int, std::unique_ptr<char[]>, unsigned int);
 
-extern template void UDPHandle::send<IPv4>(Addr, std::unique_ptr<char[]>, unsigned int);
-extern template void UDPHandle::send<IPv6>(Addr, std::unique_ptr<char[]>, unsigned int);
+extern template UVW_EXTERN void UDPHandle::send<IPv4>(Addr, std::unique_ptr<char[]>, unsigned int);
+extern template UVW_EXTERN void UDPHandle::send<IPv6>(Addr, std::unique_ptr<char[]>, unsigned int);
 
-extern template void UDPHandle::send<IPv4>(std::string, unsigned int, char *, unsigned int);
-extern template void UDPHandle::send<IPv6>(std::string, unsigned int, char *, unsigned int);
+extern template UVW_EXTERN void UDPHandle::send<IPv4>(std::string, unsigned int, char *, unsigned int);
+extern template UVW_EXTERN void UDPHandle::send<IPv6>(std::string, unsigned int, char *, unsigned int);
 
-extern template void UDPHandle::send<IPv4>(Addr, char *, unsigned int);
-extern template void UDPHandle::send<IPv6>(Addr, char *, unsigned int);
+extern template UVW_EXTERN void UDPHandle::send<IPv4>(Addr, char *, unsigned int);
+extern template UVW_EXTERN void UDPHandle::send<IPv6>(Addr, char *, unsigned int);
 
-extern template int UDPHandle::trySend<IPv4>(const sockaddr &, std::unique_ptr<char[]>, unsigned int);
-extern template int UDPHandle::trySend<IPv6>(const sockaddr &, std::unique_ptr<char[]>, unsigned int);
+extern template UVW_EXTERN int UDPHandle::trySend<IPv4>(const sockaddr &, std::unique_ptr<char[]>, unsigned int);
+extern template UVW_EXTERN int UDPHandle::trySend<IPv6>(const sockaddr &, std::unique_ptr<char[]>, unsigned int);
 
-extern template int UDPHandle::trySend<IPv4>(std::string, unsigned int, std::unique_ptr<char[]>, unsigned int);
-extern template int UDPHandle::trySend<IPv6>(std::string, unsigned int, std::unique_ptr<char[]>, unsigned int);
+extern template UVW_EXTERN int UDPHandle::trySend<IPv4>(std::string, unsigned int, std::unique_ptr<char[]>, unsigned int);
+extern template UVW_EXTERN int UDPHandle::trySend<IPv6>(std::string, unsigned int, std::unique_ptr<char[]>, unsigned int);
 
-extern template int UDPHandle::trySend<IPv4>(Addr, std::unique_ptr<char[]>, unsigned int);
-extern template int UDPHandle::trySend<IPv6>(Addr, std::unique_ptr<char[]>, unsigned int);
+extern template UVW_EXTERN int UDPHandle::trySend<IPv4>(Addr, std::unique_ptr<char[]>, unsigned int);
+extern template UVW_EXTERN int UDPHandle::trySend<IPv6>(Addr, std::unique_ptr<char[]>, unsigned int);
 
-extern template int UDPHandle::trySend<IPv4>(const sockaddr &, char *, unsigned int);
-extern template int UDPHandle::trySend<IPv6>(const sockaddr &, char *, unsigned int);
+extern template UVW_EXTERN int UDPHandle::trySend<IPv4>(const sockaddr &, char *, unsigned int);
+extern template UVW_EXTERN int UDPHandle::trySend<IPv6>(const sockaddr &, char *, unsigned int);
 
-extern template int UDPHandle::trySend<IPv4>(std::string, unsigned int, char *, unsigned int);
-extern template int UDPHandle::trySend<IPv6>(std::string, unsigned int, char *, unsigned int);
+extern template UVW_EXTERN int UDPHandle::trySend<IPv4>(std::string, unsigned int, char *, unsigned int);
+extern template UVW_EXTERN int UDPHandle::trySend<IPv6>(std::string, unsigned int, char *, unsigned int);
 
-extern template int UDPHandle::trySend<IPv4>(Addr, char *, unsigned int);
-extern template int UDPHandle::trySend<IPv6>(Addr, char *, unsigned int);
+extern template UVW_EXTERN int UDPHandle::trySend<IPv4>(Addr, char *, unsigned int);
+extern template UVW_EXTERN int UDPHandle::trySend<IPv6>(Addr, char *, unsigned int);
 
-extern template void UDPHandle::recv<IPv4>();
-extern template void UDPHandle::recv<IPv6>();
+extern template UVW_EXTERN void UDPHandle::recv<IPv4>();
+extern template UVW_EXTERN void UDPHandle::recv<IPv6>();
 
 }
 
@@ -641,5 +644,7 @@ extern template void UDPHandle::recv<IPv6>();
 #ifndef UVW_AS_LIB
 #include "udp.cpp"
 #endif
+
+UVW_MSVC_WARNING_POP();
 
 #endif // UVW_UDP_INCLUDE_H

--- a/src/uvw/underlying_type.hpp
+++ b/src/uvw/underlying_type.hpp
@@ -6,6 +6,9 @@
 #include <type_traits>
 #include <utility>
 #include "loop.h"
+#include "config.h"
+
+UVW_MSVC_WARNING_PUSH_DISABLE_DLLINTERFACE();
 
 
 namespace uvw {
@@ -115,5 +118,7 @@ private:
 
 
 }
+
+UVW_MSVC_WARNING_POP();
 
 #endif // UVW_UNDERLYING_TYPE_INCLUDE_H

--- a/src/uvw/util.cpp
+++ b/src/uvw/util.cpp
@@ -69,6 +69,10 @@ UVW_INLINE std::string UtsName::machine() const noexcept {
     return utsname ? utsname->machine : "";
 }
 
+const details::IpTraits<IPv4>::AddrFuncType details::IpTraits<IPv4>::addrFunc = &uv_ip4_addr;
+const details::IpTraits<IPv4>::NameFuncType details::IpTraits<IPv4>::nameFunc = &uv_ip4_name;
+const details::IpTraits<IPv6>::AddrFuncType details::IpTraits<IPv6>::addrFunc = &uv_ip6_addr;
+const details::IpTraits<IPv6>::NameFuncType details::IpTraits<IPv6>::nameFunc = &uv_ip6_name;
 
 UVW_INLINE PidType Utilities::OS::pid() noexcept {
     return uv_os_getpid();

--- a/src/uvw/util.h
+++ b/src/uvw/util.h
@@ -11,6 +11,9 @@
 #include <memory>
 #include <array>
 #include <uv.h>
+#include "config.h"
+
+UVW_MSVC_WARNING_PUSH_DISABLE_DLLINTERFACE();
 
 
 namespace uvw {
@@ -177,7 +180,7 @@ private:
 /**
  * @brief Windows size representation.
  */
-struct WinSize {
+struct UVW_EXTERN WinSize {
     int width; /*!< The _width_ of the given window. */
     int height; /*!< The _height_ of the given window. */
 };
@@ -214,7 +217,7 @@ using RUsage = uv_rusage_t; /*!< Library equivalent for uv_rusage_t. */
  *
  * \sa Utilities::passwd
  */
-struct Passwd {
+struct UVW_EXTERN Passwd {
     Passwd(std::shared_ptr<uv_passwd_t> pwd);
 
     /**
@@ -267,7 +270,7 @@ private:
  *
  * \sa Utilities::uname
  */
-struct UtsName {
+struct UVW_EXTERN UtsName {
     UtsName(std::shared_ptr<uv_utsname_t> utsname);
 
     /**
@@ -304,7 +307,7 @@ private:
  *
  * To be used as template parameter to switch between IPv4 and IPv6.
  */
-struct IPv4 {};
+struct UVW_EXTERN IPv4 {};
 
 
 /**
@@ -312,13 +315,13 @@ struct IPv4 {};
  *
  * To be used as template parameter to switch between IPv4 and IPv6.
  */
-struct IPv6 {};
+struct UVW_EXTERN IPv6 {};
 
 
 /**
  * @brief Address representation.
  */
-struct Addr {
+struct UVW_EXTERN Addr {
     std::string ip; /*!< Either an IPv4 or an IPv6. */
     unsigned int port; /*!< A valid service identifier. */
 };
@@ -327,7 +330,7 @@ struct Addr {
 /**
  * \brief CPU information.
  */
-struct CPUInfo {
+struct UVW_EXTERN CPUInfo {
     using CPUTime = decltype(uv_cpu_info_t::cpu_times);
 
     std::string model; /*!< The model of the CPU. */
@@ -346,7 +349,7 @@ struct CPUInfo {
 /**
  * \brief Interface address.
  */
-struct InterfaceAddress {
+struct UVW_EXTERN InterfaceAddress {
     std::string name; /*!< The name of the interface (as an example _eth0_). */
     char physical[6]; /*!< The physical address. */
     bool internal; /*!< True if it is an internal interface (as an example _loopback_), false otherwise. */
@@ -364,14 +367,13 @@ static constexpr std::size_t DEFAULT_SIZE = 128;
 template<typename>
 struct IpTraits;
 
-
 template<>
 struct IpTraits<IPv4> {
     using Type = sockaddr_in;
-    using AddrFuncType = int(*)(const char *, int, Type *);
-    using NameFuncType = int(*)(const Type *, char *, std::size_t);
-    static constexpr AddrFuncType addrFunc = &uv_ip4_addr;
-    static constexpr NameFuncType nameFunc = &uv_ip4_name;
+    using AddrFuncType = int (*)(const char*, int, Type*);
+    using NameFuncType = int (*)(const Type*, char*, std::size_t);
+    static UVW_EXTERN const AddrFuncType addrFunc;
+    static UVW_EXTERN const NameFuncType nameFunc;
     static constexpr auto sinPort(const Type *addr) { return addr->sin_port; }
 };
 
@@ -381,8 +383,8 @@ struct IpTraits<IPv6> {
     using Type = sockaddr_in6;
     using AddrFuncType = int(*)(const char *, int, Type *);
     using NameFuncType = int(*)(const Type *, char *, std::size_t);
-    static constexpr AddrFuncType addrFunc = &uv_ip6_addr;
-    static constexpr NameFuncType nameFunc = &uv_ip6_name;
+    static UVW_EXTERN const AddrFuncType addrFunc;
+    static UVW_EXTERN const NameFuncType nameFunc;
     static constexpr auto sinPort(const Type *addr) { return addr->sin6_port; }
 };
 
@@ -450,7 +452,7 @@ std::string tryRead(F &&f, Args&&... args) noexcept {
  *
  * Miscellaneous functions that don’t really belong to any other class.
  */
-struct Utilities {
+struct UVW_EXTERN Utilities {
     using MallocFuncType = void*(*)(size_t);
     using ReallocFuncType = void*(*)(void*, size_t);
     using CallocFuncType = void*(*)(size_t, size_t);
@@ -459,7 +461,7 @@ struct Utilities {
     /**
      * @brief OS dedicated utilities.
      */
-    struct OS {
+    struct UVW_EXTERN OS {
         /**
          * @brief Returns the current process id.
          *
@@ -828,5 +830,7 @@ struct Utilities {
 #ifndef UVW_AS_LIB
 #include "util.cpp"
 #endif
+
+UVW_MSVC_WARNING_POP();
 
 #endif // UVW_UTIL_INCLUDE_H

--- a/src/uvw/work.h
+++ b/src/uvw/work.h
@@ -7,6 +7,9 @@
 #include <uv.h>
 #include "request.hpp"
 #include "loop.h"
+#include "config.h"
+
+UVW_MSVC_WARNING_PUSH_DISABLE_DLLINTERFACE();
 
 
 namespace uvw {
@@ -17,7 +20,7 @@ namespace uvw {
  *
  * It will be emitted by WorkReq according with its functionalities.
  */
-struct WorkEvent {};
+struct UVW_EXTERN WorkEvent {};
 
 
 /**
@@ -34,7 +37,7 @@ struct WorkEvent {};
  * [documentation](http://docs.libuv.org/en/v1.x/threadpool.html)
  * for further details.
  */
-class WorkReq final: public Request<WorkReq, uv_work_t> {
+class UVW_EXTERN WorkReq final: public Request<WorkReq, uv_work_t> {
     using InternalTask = std::function<void(void)>;
 
     static void workCallback(uv_work_t *req);
@@ -64,5 +67,7 @@ private:
 #ifndef UVW_AS_LIB
 #include "work.cpp"
 #endif
+
+UVW_MSVC_WARNING_POP();
 
 #endif // UVW_WORK_INCLUDE_H

--- a/src/uvw/work.h
+++ b/src/uvw/work.h
@@ -37,7 +37,7 @@ struct UVW_EXTERN WorkEvent {};
  * [documentation](http://docs.libuv.org/en/v1.x/threadpool.html)
  * for further details.
  */
-class UVW_EXTERN WorkReq final: public Request<WorkReq, uv_work_t> {
+class UVW_EXTERN WorkReq final: public Request<WorkReq, uv_work_t, WorkEvent> {
     using InternalTask = std::function<void(void)>;
 
     static void workCallback(uv_work_t *req);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -46,8 +46,8 @@ function(ADD_UVW_TEST TEST_NAME TEST_SOURCE)
         ${TEST_NAME}
         PRIVATE
             $<$<TARGET_EXISTS:uvw::uvw>:uvw::uvw>
-            $<$<TARGET_EXISTS:uvw::uvw>:uv::uv-static>
-            $<$<TARGET_EXISTS:uvw::uvw-static>:uvw::uvw-static>
+            $<$<TARGET_EXISTS:uv::uv-shared>:uv::uv-shared>
+            $<$<TARGET_EXISTS:uvw::uvw-shared>:uvw::uvw-shared>
             GTest::Main
             Threads::Threads
             ${LIBRT}

--- a/test/uvw/emitter.cpp
+++ b/test/uvw/emitter.cpp
@@ -5,7 +5,7 @@
 
 struct FakeEvent { };
 
-struct TestEmitter: uvw::Emitter<TestEmitter> {
+struct TestEmitter: uvw::Emitter<TestEmitter, uvw::ErrorEvent, FakeEvent> {
     void emit() { publish(FakeEvent{}); }
 };
 

--- a/test/uvw/signal.cpp
+++ b/test/uvw/signal.cpp
@@ -7,7 +7,7 @@ TEST(Signal, Start) {
     auto handle = loop->resource<uvw::SignalHandle>();
 
     handle->on<uvw::ErrorEvent>([](auto &&...) { FAIL(); });
-    handle->on<uvw::CheckEvent>([](auto &&...) { FAIL(); });
+    //handle->on<uvw::CheckEvent>([](auto &&...) { FAIL(); });
 
     handle->start(2);
 
@@ -27,7 +27,7 @@ TEST(Signal, OneShot) {
     auto handle = loop->resource<uvw::SignalHandle>();
 
     handle->on<uvw::ErrorEvent>([](auto &&...) { FAIL(); });
-    handle->on<uvw::CheckEvent>([](auto &&...) { FAIL(); });
+    //handle->on<uvw::CheckEvent>([](auto &&...) { FAIL(); });
 
     handle->oneShot(2);
 


### PR DESCRIPTION
When building a DLL on Windows or building a shared library with
`-fvisibility=hidden` on Unix, class with functions implemented in a cpp
file must be exported.

This mean `__declspec(dllexport)` on Windows, and
`__attribute__((visibility(default)))` on Unix.

Changes made:
 - `UVW_EXTERN` on all non templated classes.

 - Declare `UVW_EXTERN` in config.h.

 - Put `UVW_EXTERN` on all extern explicit template instantiations.

 - Put `UVW_EXTERN` on instantiation of `Flags<T>` from an exported template.
   MSVC was throwing a `C4251` warning for these, so I'm exported them too
   via an explicit template instantiation. This is not required for the code
   to link in fact.

 - Also add `UVW_MSVC_WARNING_PUSH_DISABLE_DLLINTERFACE()` for MSVC as it
   outputs many `C4251` warnings when an exported class uses a non exported
   template in the standard library. This means the user of the DLL must use
   similar enough compiler and flags so the C++ ABI is the same.
   There are these macro in all headers so the warning is still enabled for
   user code, if the user happen to use `__declspec(dllexport)` too.

 - Almost all exported classes derive from a template class. This doesn't
   trigger warning `C4275` because the base template class use the derived
   class in its template arguments. See last point here: https://docs.microsoft.com/en-us/cpp/cpp/general-rules-and-limitations?view=vs-2019

 - Change tests link libraries to use `uvw-shared` and `uv-shared` instead.
   So this will test that functions are really available from the DLL/.so.

 - Add CMake code to declare `USING_UVW_SHARED` or `BUILDING_UVW_SHARED` as
   appropriate.

 - Enable `CXX_VISIBILITY_HIDDEN` so only explicitly exported symbols are
   exported.

**Currently not working because of static variables in `Emitter<>::next_type()`
and `Emitter<>::event_type<>()`.**

Fixes: #196