### PR TITLE
add openbsd support

### DIFF
--- a/src/uvw/handle.hpp
+++ b/src/uvw/handle.hpp
@@ -264,7 +264,7 @@ public:
      * @return The file descriptor attached to the hande or a negative value in
      * case of errors.
      */
-    OSFileDescriptor fileno() const {
+    OSFileDescriptor fd() const {
         uv_os_fd_t fd;
         uv_fileno(this->template get<uv_handle_t>(), &fd);
         return fd;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -29,7 +29,6 @@ else()
 
     target_compile_features(gtest PUBLIC cxx_std_17)
     target_compile_features(gtest_main PUBLIC cxx_std_17)
-    target_compile_options(gtest PRIVATE -Wno-error)
     target_compile_features(gmock PUBLIC cxx_std_17)
     target_compile_features(gmock_main PUBLIC cxx_std_17)
 endif()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -29,14 +29,13 @@ else()
 
     target_compile_features(gtest PUBLIC cxx_std_17)
     target_compile_features(gtest_main PUBLIC cxx_std_17)
+    target_compile_options(gtest PRIVATE -Wno-error)
     target_compile_features(gmock PUBLIC cxx_std_17)
     target_compile_features(gmock_main PUBLIC cxx_std_17)
 endif()
 
 if(WIN32)
     set(WINSOCK2 ws2_32)
-elseif(NOT APPLE)
-    find_library(LIBRT rt)
 endif()
 
 function(ADD_UVW_TEST TEST_NAME TEST_SOURCE)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -31,6 +31,10 @@ else()
     target_compile_features(gtest_main PUBLIC cxx_std_17)
     target_compile_features(gmock PUBLIC cxx_std_17)
     target_compile_features(gmock_main PUBLIC cxx_std_17)
+
+    if(CMAKE_SYSTEM_NAME MATCHES OpenBSD)
+        target_compile_options(gtest PRIVATE -Wno-error)
+    endif()
 endif()
 
 if(WIN32)
@@ -101,6 +105,10 @@ ADD_UVW_TEST(udp uvw/udp.cpp)
 ADD_UVW_TEST(underlying_type uvw/underlying_type.cpp)
 ADD_UVW_TEST(util uvw/util.cpp)
 ADD_UVW_TEST(work uvw/work.cpp)
+
+if(NOT CMAKE_SYSTEM_NAME MATCHES OpenBSD)
+    ADD_UVW_DIR_TEST(file_req_sendfile uvw/file_req_sendfile.cpp)
+endif()
 
 if(BUILD_DNS_TEST)
     ADD_UVW_TEST(dns uvw/dns.cpp)

--- a/test/uvw/file_req.cpp
+++ b/test/uvw/file_req.cpp
@@ -373,65 +373,6 @@ TEST(FileReq, TruncateSync) {
 }
 
 
-TEST(FileReq, SendFile) {
-    const std::string srcFilename = std::string{TARGET_FILE_REQ_DIR} + std::string{"/src.file"};
-    const std::string dstFilename = std::string{TARGET_FILE_REQ_DIR} + std::string{"/dst.file"};
-
-    auto loop = uvw::Loop::getDefault();
-    auto srcReq = loop->resource<uvw::FileReq>();
-    auto dstReq = loop->resource<uvw::FileReq>();
-
-    bool checkFileSendFileEvent = false;
-
-    dstReq->on<uvw::ErrorEvent>([](const auto &, auto &) { FAIL(); });
-    srcReq->on<uvw::ErrorEvent>([](const auto &, auto &) { FAIL(); });
-
-    dstReq->on<uvw::FsEvent<uvw::FileReq::Type::OPEN>>([&srcReq](const auto &, auto &req) {
-        srcReq->sendfile(static_cast<uvw::FileHandle>(req), 0, 0);
-    });
-
-    srcReq->on<uvw::FsEvent<uvw::FileReq::Type::SENDFILE>>([&checkFileSendFileEvent, &dstReq](const auto &, auto &req) {
-        ASSERT_FALSE(checkFileSendFileEvent);
-        checkFileSendFileEvent = true;
-        dstReq->close();
-        req.close();
-    });
-
-    srcReq->on<uvw::FsEvent<uvw::FileReq::Type::OPEN>>([&dstFilename, &dstReq](const auto &, auto &) {
-        auto flags = uvw::Flags<uvw::FileReq::FileOpen>::from<uvw::FileReq::FileOpen::CREAT, uvw::FileReq::FileOpen::WRONLY, uvw::FileReq::FileOpen::TRUNC>();
-        dstReq->open(dstFilename, flags, 0644);
-    });
-
-    auto flags = uvw::Flags<uvw::FileReq::FileOpen>::from<uvw::FileReq::FileOpen::CREAT, uvw::FileReq::FileOpen::RDONLY, uvw::FileReq::FileOpen::TRUNC>();
-    srcReq->open(srcFilename, flags, 0644);
-
-    loop->run();
-
-    ASSERT_TRUE(checkFileSendFileEvent);
-}
-
-
-TEST(FileReq, SendFileSync) {
-    const std::string srcFilename = std::string{TARGET_FILE_REQ_DIR} + std::string{"/src.file"};
-    const std::string dstFilename = std::string{TARGET_FILE_REQ_DIR} + std::string{"/dst.file"};
-
-    auto loop = uvw::Loop::getDefault();
-    auto srcReq = loop->resource<uvw::FileReq>();
-    auto dstReq = loop->resource<uvw::FileReq>();
-
-    ASSERT_TRUE(srcReq->openSync(srcFilename, O_CREAT | O_RDONLY | O_TRUNC, 0644));
-    ASSERT_TRUE(dstReq->openSync(dstFilename, O_CREAT | O_WRONLY | O_TRUNC, 0644));
-
-    auto sendfileR = srcReq->sendfileSync(static_cast<uvw::FileHandle>(*dstReq), 0, 0);
-
-    ASSERT_TRUE(sendfileR.first);
-    ASSERT_TRUE(srcReq->closeSync());
-    ASSERT_TRUE(dstReq->closeSync());
-
-    loop->run();
-}
-
-
 TEST(FileReq, Chmod) {
     const std::string filename = std::string{TARGET_FILE_REQ_DIR} + std::string{"/test.file"};
 

--- a/test/uvw/file_req_sendfile.cpp
+++ b/test/uvw/file_req_sendfile.cpp
@@ -1,0 +1,67 @@
+#include <gtest/gtest.h>
+#include <uvw.hpp>
+#include <chrono>
+
+#ifdef _WIN32
+#define _CRT_DECLARE_NONSTDC_NAMES 1
+#include <fcntl.h>
+#endif
+
+TEST(FileReq, SendFile) {
+    const std::string srcFilename = std::string{TARGET_FILE_REQ_SENDFILE_DIR} + std::string{"/src.file"};
+    const std::string dstFilename = std::string{TARGET_FILE_REQ_SENDFILE_DIR} + std::string{"/dst.file"};
+
+    auto loop = uvw::Loop::getDefault();
+    auto srcReq = loop->resource<uvw::FileReq>();
+    auto dstReq = loop->resource<uvw::FileReq>();
+
+    bool checkFileSendFileEvent = false;
+
+    dstReq->on<uvw::ErrorEvent>([](const auto &, auto &) { FAIL(); });
+    srcReq->on<uvw::ErrorEvent>([](const auto &, auto &) { FAIL(); });
+
+    dstReq->on<uvw::FsEvent<uvw::FileReq::Type::OPEN>>([&srcReq](const auto &, auto &req) {
+        srcReq->sendfile(static_cast<uvw::FileHandle>(req), 0, 0);
+    });
+
+    srcReq->on<uvw::FsEvent<uvw::FileReq::Type::SENDFILE>>([&checkFileSendFileEvent, &dstReq](const auto &, auto &req) {
+        ASSERT_FALSE(checkFileSendFileEvent);
+        checkFileSendFileEvent = true;
+        dstReq->close();
+        req.close();
+    });
+
+    srcReq->on<uvw::FsEvent<uvw::FileReq::Type::OPEN>>([&dstFilename, &dstReq](const auto &, auto &) {
+        auto flags = uvw::Flags<uvw::FileReq::FileOpen>::from<uvw::FileReq::FileOpen::CREAT, uvw::FileReq::FileOpen::WRONLY, uvw::FileReq::FileOpen::TRUNC>();
+        dstReq->open(dstFilename, flags, 0644);
+    });
+
+    auto flags = uvw::Flags<uvw::FileReq::FileOpen>::from<uvw::FileReq::FileOpen::CREAT, uvw::FileReq::FileOpen::RDONLY, uvw::FileReq::FileOpen::TRUNC>();
+    srcReq->open(srcFilename, flags, 0644);
+
+    loop->run();
+
+    ASSERT_TRUE(checkFileSendFileEvent);
+}
+
+
+TEST(FileReq, SendFileSync) {
+    const std::string srcFilename = std::string{TARGET_FILE_REQ_SENDFILE_DIR} + std::string{"/src.file"};
+    const std::string dstFilename = std::string{TARGET_FILE_REQ_SENDFILE_DIR} + std::string{"/dst.file"};
+
+    auto loop = uvw::Loop::getDefault();
+    auto srcReq = loop->resource<uvw::FileReq>();
+    auto dstReq = loop->resource<uvw::FileReq>();
+
+    ASSERT_TRUE(srcReq->openSync(srcFilename, O_CREAT | O_RDONLY | O_TRUNC, 0644));
+    ASSERT_TRUE(dstReq->openSync(dstFilename, O_CREAT | O_WRONLY | O_TRUNC, 0644));
+
+    auto sendfileR = srcReq->sendfileSync(static_cast<uvw::FileHandle>(*dstReq), 0, 0);
+
+    ASSERT_TRUE(sendfileR.first);
+    ASSERT_TRUE(srcReq->closeSync());
+    ASSERT_TRUE(dstReq->closeSync());
+
+    loop->run();
+}
+

--- a/test/uvw/handle.cpp
+++ b/test/uvw/handle.cpp
@@ -42,7 +42,7 @@ TEST(Handle, Functionalities) {
     ASSERT_EQ(handle->recvBufferSize(), static_cast<decltype(handle->recvBufferSize())>(0));
     ASSERT_FALSE(handle->recvBufferSize(0));
 
-    ASSERT_NO_THROW(handle->fileno());
+    ASSERT_NO_THROW(handle->fd());
 }
 
 


### PR DESCRIPTION
Renames fileno() so it doesn't clash with OpenBSD's macro expansion.

Makes minor changes to build steps so the test suite compiles and runs
on OpenBSD.

See https://github.com/skypjack/uvw/issues/201 for full context