### PR TITLE
basehandle::type() in uv_walk which is in a timer callback causes...

### DIFF
--- a/src/uvw/loop.h
+++ b/src/uvw/loop.h
@@ -46,6 +46,7 @@ enum class UVRunMode: std::underlying_type_t<uv_run_mode> {
  * This can help to end all the pending requests by closing the handles.
  */
 struct BaseHandle {
+    virtual ~BaseHandle() = default;
     /**
      * @brief Gets the category of the handle.
      *

--- a/test/uvw/timer.cpp
+++ b/test/uvw/timer.cpp
@@ -122,3 +122,17 @@ TEST(Timer, Fake) {
 
     loop->run();
 }
+
+TEST(Timer, BaseHandleWalk) {
+    auto loop = uvw::Loop::getDefault();
+    auto timer = loop->resource<uvw::TimerHandle>();
+    timer->on<uvw::TimerEvent>([](const auto &event, uvw::TimerHandle &handle) {
+        auto &loop = handle.loop();
+        loop.walk([](uvw::BaseHandle& h){
+            h.type();
+        });
+        handle.close();
+    });
+    timer->start(uvw::TimerHandle::Time{1000}, uvw::TimerHandle::Time{1000});
+    loop->run();
+}


### PR DESCRIPTION
basehandle::type() in uv_walk which is in a timer callback causes double free

  Close #212

Signed-off-by: Fiorentino Ing. Stefano <stefano.fiore84@gmail.com>