### PR TITLE
Add compatibility for using uvw with older libuv versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,6 +28,29 @@ jobs:
         CTEST_OUTPUT_ON_FAILURE: 1
       run: ctest --timeout 5 -C Debug -j2
 
+  linux-native-libuv:
+    timeout-minutes: 60
+
+    strategy:
+      matrix:
+        os: [ubuntu-18.04, ubuntu-20.04]
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Compile tests (${{ matrix.os }} system libuv)
+      working-directory: build
+      run: |
+        sudo apt-get -o=Dpkg::Use-Pty=0 -qy install libuv1-dev
+        cmake -DBUILD_UVW_LIBS=ON -DFETCH_LIBUV=OFF -DBUILD_TESTING=ON ..
+        make -j2
+    - name: Run tests
+      working-directory: build
+      env:
+        CTEST_OUTPUT_ON_FAILURE: 1
+      run: ctest --timeout 5 -C Debug -j2
+
   windows:
     timeout-minutes: 60
     runs-on: windows-latest

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,6 +62,10 @@ endif()
 
 option(FETCH_LIBUV "Fetch the libuv repo using CMake FetchContent facility" ON)
 function(fetch_libuv)
+    if (TARGET uv::uv-static)
+        return()
+    endif()
+
     if (FETCH_LIBUV)
         include(FetchContent)
 
@@ -83,7 +87,18 @@ function(fetch_libuv)
 
         set_target_properties(uv_a PROPERTIES POSITION_INDEPENDENT_CODE 1)
         set_target_properties(uv PROPERTIES POSITION_INDEPENDENT_CODE 1)
-    endif(FETCH_LIBUV)
+    else()
+        find_library(UV_STATIC NAMES uv_a libuv.a)
+        if(UV_STATIC)
+            message(STATUS "Using libuv at ${UV_STATIC}")
+            add_library(uv_a STATIC IMPORTED)
+            target_link_libraries(uv_a INTERFACE dl)
+            set_property(TARGET uv_a PROPERTY IMPORTED_LOCATION "${UV_STATIC}")
+            add_library(uv::uv-static ALIAS uv_a)
+        else()
+            message(FATAL_ERROR "Could not find static libuv or libuv_a")
+        endif()
+    endif()
 endfunction()
 
 #

--- a/src/uvw/config.h
+++ b/src/uvw/config.h
@@ -9,4 +9,7 @@
 #endif
 
 
+#define LIBUV_VERSION_AT_LEAST(a, b, c) (UV_VERSION_HEX >= (((a) << 16) | ((b) << 8) | (c)))
+
+
 #endif

--- a/src/uvw/fs.cpp
+++ b/src/uvw/fs.cpp
@@ -239,6 +239,7 @@ UVW_INLINE void FsReq::fsReadlinkCallback(uv_fs_t *req) {
 }
 
 
+#if LIBUV_VERSION_AT_LEAST(1,28,0)
 UVW_INLINE void FsReq::fsReaddirCallback(uv_fs_t *req) {
     auto ptr = reserve(req);
 
@@ -249,6 +250,7 @@ UVW_INLINE void FsReq::fsReaddirCallback(uv_fs_t *req) {
         ptr->publish(FsEvent<Type::READDIR>{dir->dirents[0].name, static_cast<EntryType>(dir->dirents[0].type), !req->result});
     }
 }
+#endif
 
 
 UVW_INLINE FsReq::~FsReq() noexcept {
@@ -292,6 +294,7 @@ UVW_INLINE std::pair<bool, const char *> FsReq::mkdtempSync(std::string tpl) {
 }
 
 
+#if LIBUV_VERSION_AT_LEAST(1,34,0)
 UVW_INLINE void FsReq::mkstemp(std::string tpl) {
     cleanupAndInvoke(&uv_fs_mkstemp, parent(), get(), tpl.data(), &fsResultCallback<Type::MKSTEMP>);
 }
@@ -310,8 +313,10 @@ UVW_INLINE std::pair<bool, std::pair<std::string, std::size_t>> FsReq::mkstempSy
 
     return ret;
 }
+#endif
 
 
+#if LIBUV_VERSION_AT_LEAST(1,36,0)
 UVW_INLINE void FsReq::lutime(std::string path, Time atime, Time mtime) {
     cleanupAndInvoke(&uv_fs_lutime, parent(), get(), path.data(), atime.count(), mtime.count(), &fsGenericCallback<Type::LUTIME>);
 }
@@ -322,6 +327,7 @@ UVW_INLINE bool FsReq::lutimeSync(std::string path, Time atime, Time mtime) {
     cleanupAndInvokeSync(&uv_fs_lutime, parent(), req, path.data(), atime.count(), mtime.count());
     return !(req->result < 0);
 }
+#endif
 
 
 UVW_INLINE void FsReq::rmdir(std::string path) {
@@ -390,6 +396,7 @@ UVW_INLINE std::pair<bool, Stat> FsReq::lstatSync(std::string path) {
 }
 
 
+#if LIBUV_VERSION_AT_LEAST(1,31,0)
 UVW_INLINE void FsReq::statfs(std::string path) {
     cleanupAndInvoke(&uv_fs_statfs, parent(), get(), path.data(), &fsStatfsCallback);
 }
@@ -400,6 +407,7 @@ UVW_INLINE std::pair<bool, Statfs> FsReq::statfsSync(std::string path) {
     cleanupAndInvokeSync(&uv_fs_statfs, parent(), req, path.data());
     return std::make_pair(!(req->result < 0), *static_cast<uv_statfs_t *>(req->ptr));
 }
+#endif
 
 
 UVW_INLINE void FsReq::rename(std::string old, std::string path) {
@@ -523,6 +531,7 @@ UVW_INLINE bool FsReq::chownSync(std::string path, Uid uid, Gid gid) {
 }
 
 
+#if LIBUV_VERSION_AT_LEAST(1,21,0)
 UVW_INLINE void FsReq::lchown(std::string path, Uid uid, Gid gid) {
     cleanupAndInvoke(&uv_fs_lchown, parent(), get(), path.data(), uid, gid, &fsGenericCallback<Type::LCHOWN>);
 }
@@ -533,8 +542,10 @@ UVW_INLINE bool FsReq::lchownSync(std::string path, Uid uid, Gid gid) {
     cleanupAndInvokeSync(&uv_fs_lchown, parent(), req, path.data(), uid, gid);
     return !(req->result < 0);
 }
+#endif
 
 
+#if LIBUV_VERSION_AT_LEAST(1,28,0)
 UVW_INLINE void FsReq::opendir(std::string path) {
     cleanupAndInvoke(&uv_fs_opendir, parent(), get(), path.data(), &fsGenericCallback<Type::OPENDIR>);
 }
@@ -579,6 +590,7 @@ UVW_INLINE std::pair<bool, std::pair<FsReq::EntryType, const char *>> FsReq::rea
     cleanupAndInvokeSync(&uv_fs_readdir, parent(), req, dir);
     return {req->result != 0, { static_cast<EntryType>(dirents[0].type), dirents[0].name }};
 }
+#endif
 
 
 UVW_INLINE OSFileDescriptor FsHelper::handle(FileHandle file) noexcept {
@@ -586,9 +598,11 @@ UVW_INLINE OSFileDescriptor FsHelper::handle(FileHandle file) noexcept {
 }
 
 
+#if LIBUV_VERSION_AT_LEAST(1,23,0)
 UVW_INLINE FileHandle FsHelper::open(OSFileDescriptor descriptor) noexcept {
     return uv_open_osfhandle(descriptor);
 }
+#endif
 
 
 }

--- a/src/uvw/fs.h
+++ b/src/uvw/fs.h
@@ -50,13 +50,23 @@ enum class UVFsType: std::underlying_type_t<uv_fs_type> {
     FCHOWN = UV_FS_FCHOWN,
     REALPATH = UV_FS_REALPATH,
     COPYFILE = UV_FS_COPYFILE,
+#if LIBUV_VERSION_AT_LEAST(1,21,0)
     LCHOWN = UV_FS_LCHOWN,
+#endif
+#if LIBUV_VERSION_AT_LEAST(1,28,0)
     OPENDIR = UV_FS_OPENDIR,
     READDIR = UV_FS_READDIR,
     CLOSEDIR = UV_FS_CLOSEDIR,
+#endif
+#if LIBUV_VERSION_AT_LEAST(1,31,0)
     STATFS = UV_FS_STATFS,
+#endif
+#if LIBUV_VERSION_AT_LEAST(1,34,0)
     MKSTEMP = UV_FS_MKSTEMP,
-    LUTIME = UV_FS_LUTIME
+#endif
+#if LIBUV_VERSION_AT_LEAST(1,36,0)
+    LUTIME = UV_FS_LUTIME,
+#endif
 };
 
 
@@ -80,7 +90,9 @@ enum class UVFileOpenFlags: int {
     DSYNC = UV_FS_O_DSYNC,
     EXCL = UV_FS_O_EXCL,
     EXLOCK = UV_FS_O_EXLOCK,
+#if LIBUV_VERSION_AT_LEAST(1,31,0)
     FILEMAP = UV_FS_O_FILEMAP,
+#endif
     NOATIME = UV_FS_O_NOATIME,
     NOCTTY = UV_FS_O_NOCTTY,
     NOFOLLOW = UV_FS_O_NOFOLLOW,
@@ -100,8 +112,10 @@ enum class UVFileOpenFlags: int {
 
 enum class UVCopyFileFlags: int {
     EXCL = UV_FS_COPYFILE_EXCL,
+#if LIBUV_VERSION_AT_LEAST(1,20,0)
     FICLONE = UV_FS_COPYFILE_FICLONE,
-    FICLONE_FORCE = UV_FS_COPYFILE_FICLONE_FORCE
+    FICLONE_FORCE = UV_FS_COPYFILE_FICLONE_FORCE,
+#endif
 };
 
 
@@ -150,13 +164,13 @@ enum class UVSymLinkFlags: int {
  * * `FsRequest::Type::FCHOWN`
  * * `FsRequest::Type::REALPATH`
  * * `FsRequest::Type::COPYFILE`
- * * `FsRequest::Type::LCHOWN`
- * * `FsRequest::Type::OPENDIR`
- * * `FsRequest::Type::READDIR`
- * * `FsRequest::Type::CLOSEDIR`
- * * `FsRequest::Type::STATFS`
- * * `FsRequest::Type::MKSTEMP`
- * * `FsRequest::Type::LUTIME`
+ * * `FsRequest::Type::LCHOWN` (libuv 1.21.0+)
+ * * `FsRequest::Type::OPENDIR` (libuv 1.28.0+)
+ * * `FsRequest::Type::READDIR` (libuv 1.28.0+)
+ * * `FsRequest::Type::CLOSEDIR` (libuv 1.28.0+)
+ * * `FsRequest::Type::STATFS` (libuv 1.31.0+)
+ * * `FsRequest::Type::MKSTEMP` (libuv 1.34.0+)
+ * * `FsRequest::Type::LUTIME` (libuv 1.36.0+)
  *
  * It will be emitted by FsReq and/or FileReq according with their
  * functionalities.
@@ -276,6 +290,7 @@ struct FsEvent<details::UVFsType::LSTAT> {
 };
 
 
+#if LIBUV_VERSION_AT_LEAST(1,31,0)
 /**
  * @brief FsEvent event specialization for `FsRequest::Type::STATFS`.
  *
@@ -291,8 +306,10 @@ struct FsEvent<details::UVFsType::STATFS> {
     const char * path; /*!< The path affecting the request. */
     Statfs statfs; /*!< An initialized instance of Statfs. */
 };
+#endif
 
 
+#if LIBUV_VERSION_AT_LEAST(1,34,0)
 /**
  * @brief FsEvent event specialization for `FsRequest::Type::MKSTEMP`.
  *
@@ -308,6 +325,7 @@ struct FsEvent<details::UVFsType::MKSTEMP> {
     const char * path; /*!< The created file path. */
     std::size_t descriptor; /*!< The file descriptor as an integer. */
 };
+#endif
 
 
 /**
@@ -345,6 +363,7 @@ struct FsEvent<details::UVFsType::READLINK> {
 };
 
 
+#if LIBUV_VERSION_AT_LEAST(1,28,0)
 /**
  * @brief FsEvent event specialization for `FsRequest::Type::READDIR`.
  *
@@ -363,6 +382,7 @@ struct FsEvent<details::UVFsType::READDIR> {
     EntryType type; /*!< The entry type. */
     bool eos; /*!< True if there a no more entries to read. */
 };
+#endif
 
 
 /**
@@ -394,11 +414,13 @@ protected:
         else { ptr->publish(FsEvent<e>{req->path, req->statbuf}); }
     }
 
+#if LIBUV_VERSION_AT_LEAST(1,31,0)
     static void fsStatfsCallback(uv_fs_t *req) {
         auto ptr = Request<T, uv_fs_t>::reserve(req);
         if(req->result < 0) { ptr->publish(ErrorEvent{req->result}); }
         else { ptr->publish(FsEvent<Type::STATFS>{req->path, *static_cast<Statfs *>(req->ptr)}); }
     }
+#endif
 
     template<typename... Args>
     void cleanupAndInvoke(Args&&... args) {
@@ -476,7 +498,7 @@ public:
      * * `FileReq::FileOpen::DSYNC`
      * * `FileReq::FileOpen::EXCL`
      * * `FileReq::FileOpen::EXLOCK`
-     * * `FileReq::FileOpen::FILEMAP`
+     * * `FileReq::FileOpen::FILEMAP` (libuv 1.31.0+)
      * * `FileReq::FileOpen::NOATIME`
      * * `FileReq::FileOpen::NOCTTY`
      * * `FileReq::FileOpen::NOFOLLOW`
@@ -514,7 +536,7 @@ public:
      * * `FileReq::FileOpen::DSYNC`
      * * `FileReq::FileOpen::EXCL`
      * * `FileReq::FileOpen::EXLOCK`
-     * * `FileReq::FileOpen::FILEMAP`
+     * * `FileReq::FileOpen::FILEMAP` (libuv 1.31.0+)
      * * `FileReq::FileOpen::NOATIME`
      * * `FileReq::FileOpen::NOCTTY`
      * * `FileReq::FileOpen::NOFOLLOW`
@@ -786,7 +808,9 @@ private:
  */
 class FsReq final: public FsRequest<FsReq> {
     static void fsReadlinkCallback(uv_fs_t *req);
+#if LIBUV_VERSION_AT_LEAST(1,28,0)
     static void fsReaddirCallback(uv_fs_t *req);
+#endif
 
 public:
     using CopyFile = details::UVCopyFileFlags;
@@ -853,6 +877,7 @@ public:
      */
     std::pair<bool, const char *> mkdtempSync(std::string tpl);
 
+#if LIBUV_VERSION_AT_LEAST(1,34,0)
     /**
      * @brief Async [mkstemp](https://linux.die.net/man/3/mkstemp).
      *
@@ -884,7 +909,9 @@ public:
      * * The second parameter is a composed value (see above).
      */
     std::pair<bool, std::pair<std::string, std::size_t>> mkstempSync(std::string tpl);
+#endif
 
+#if LIBUV_VERSION_AT_LEAST(1,36,0)
     /**
      * @brief Async [lutime](http://linux.die.net/man/3/lutimes).
      *
@@ -909,6 +936,7 @@ public:
      * @return True in case of success, false otherwise.
      */
     bool lutimeSync(std::string path, Time atime, Time mtime);
+#endif
 
     /**
      * @brief Async [rmdir](http://linux.die.net/man/2/rmdir).
@@ -1023,6 +1051,7 @@ public:
      */
     std::pair<bool, Stat> lstatSync(std::string path);
 
+#if LIBUV_VERSION_AT_LEAST(1,31,0)
     /**
      * @brief Async [statfs](http://linux.die.net/man/2/statfs).
      *
@@ -1049,6 +1078,7 @@ public:
      * * An initialized instance of Statfs.
      */
     std::pair<bool, Statfs> statfsSync(std::string path);
+#endif
 
     /**
      * @brief Async [rename](http://linux.die.net/man/2/rename).
@@ -1083,10 +1113,10 @@ public:
      * it exists).
      * * `FsReq::CopyFile::FICLONE`: If present, it will attempt to create a
      * copy-on-write reflink. If the underlying platform does not support
-     * copy-on-write, then a fallback copy mechanism is used.
+     * copy-on-write, then a fallback copy mechanism is used. Requires libuv 1.20.0+.
      * * `FsReq::CopyFile::FICLONE_FORCE`: If present, it will attempt to create
      * a copy-on-write reflink. If the underlying platform does not support
-     * copy-on-write, then an error is returned.
+     * copy-on-write, then an error is returned. Requires libuv 1.20.0+.
      *
      * @warning
      * If the destination path is created, but an error occurs while copying the
@@ -1304,11 +1334,13 @@ public:
      */
     bool chownSync(std::string path, Uid uid, Gid gid);
 
+#if LIBUV_VERSION_AT_LEAST(1,21,0)
     /**
      * @brief Async [lchown](https://linux.die.net/man/2/lchown).
      *
      * Emit a `FsEvent<FsReq::Type::LCHOWN>` event when completed.<br/>
      * Emit an ErrorEvent event in case of errors.
+     * Requires libuv 1.21.0+.
      *
      * @param path Path, as described in the official documentation.
      * @param uid UID, as described in the official documentation.
@@ -1317,19 +1349,22 @@ public:
     void lchown(std::string path, Uid uid, Gid gid);
 
     /**
-     * @brief Sync [lchown](https://linux.die.net/man/2/lchown).
+     * @brief Sync [lchown](https://linux.die.net/man/2/lchown). (libuv 1.21.0+)
      * @param path Path, as described in the official documentation.
      * @param uid UID, as described in the official documentation.
      * @param gid GID, as described in the official documentation.
      * @return True in case of success, false otherwise.
      */
     bool lchownSync(std::string path, Uid uid, Gid gid);
+#endif
 
+#if LIBUV_VERSION_AT_LEAST(1,28,0)
     /**
      * @brief Opens a path asynchronously as a directory stream.
      *
      * Emit a `FsEvent<FsReq::Type::OPENDIR>` event when completed.<br/>
      * Emit an ErrorEvent event in case of errors.
+     * Requires libuv 1.28.0+.
      *
      * The contents of the directory can be iterated over by means of the
      * `readdir` od `readdirSync` member functions. The memory allocated by this
@@ -1345,6 +1380,7 @@ public:
      * The contents of the directory can be iterated over by means of the
      * `readdir` od `readdirSync` member functions. The memory allocated by this
      * function must be freed by calling `closedir` or `closedirSync`.
+     * Requires libuv 1.28.0+.
      *
      * @param path The path to open as a directory stream.
      * @return True in case of success, false otherwise.
@@ -1356,6 +1392,7 @@ public:
      *
      * Emit a `FsEvent<FsReq::Type::CLOSEDIR>` event when completed.<br/>
      * Emit an ErrorEvent event in case of errors.
+     * Requires libuv 1.28.0+.
      *
      * It frees also the memory allocated internally when a path has been opened
      * as a directory stream.
@@ -1367,6 +1404,7 @@ public:
      *
      * It frees also the memory allocated internally when a path has been opened
      * as a directory stream.
+     * Requires libuv 1.28.0+.
      *
      * @return True in case of success, false otherwise.
      */
@@ -1378,6 +1416,7 @@ public:
      *
      * Emit a `FsEvent<FsReq::Type::READDIR>` event when completed.<br/>
      * Emit an ErrorEvent event in case of errors.
+     * Requires libuv 1.28.0+.
      *
      * This function isn't thread safe. Moreover, it doesn't return the `.` and
      * `..` entries.
@@ -1411,6 +1450,8 @@ public:
      * This function isn't thread safe. Moreover, it doesn't return the `.` and
      * `..` entries.
      *
+     * Requires libuv 1.28.0+.
+     *
      * @return A pair where:
      *
      * * The first parameter is a boolean value that indicates if the current
@@ -1418,6 +1459,7 @@ public:
      * * The second parameter is a composed value (see above).
      */
     std::pair<bool, std::pair<EntryType, const char *>> readdirSync();
+#endif
 
 private:
     uv_dirent_t dirents[1];
@@ -1438,6 +1480,7 @@ struct FsHelper {
      */
     static OSFileDescriptor handle(FileHandle file) noexcept;
 
+#if LIBUV_VERSION_AT_LEAST(1,23,0)
     /**
      * @brief Gets the file descriptor.
      *
@@ -1447,8 +1490,10 @@ struct FsHelper {
      * Note that the return value is still owned by the C runtime, any attempts
      * to close it or to use it after closing the handle may lead to
      * malfunction.
+     * Requires libuv 1.23.0+.
      */
     static FileHandle open(OSFileDescriptor descriptor) noexcept;
+#endif
 };
 
 

--- a/src/uvw/loop.cpp
+++ b/src/uvw/loop.cpp
@@ -97,9 +97,11 @@ UVW_INLINE std::pair<bool, Loop::Time> Loop::timeout() const noexcept {
 }
 
 
+#if LIBUV_VERSION_AT_LEAST(1,39,0)
 UVW_INLINE Loop::Time Loop::idleTime() const noexcept {
     return Time{uv_metrics_idle_time(loop.get())};
 }
+#endif
 
 
 UVW_INLINE Loop::Time Loop::now() const noexcept {

--- a/src/uvw/loop.h
+++ b/src/uvw/loop.h
@@ -40,7 +40,9 @@ namespace details {
 
 enum class UVLoopOption: std::underlying_type_t<uv_loop_option> {
     BLOCK_SIGNAL = UV_LOOP_BLOCK_SIGNAL,
-    IDLE_TIME = UV_METRICS_IDLE_TIME
+#if LIBUV_VERSION_AT_LEAST(1,39,0)
+    IDLE_TIME = UV_METRICS_IDLE_TIME,
+#endif
 };
 
 
@@ -233,12 +235,14 @@ public:
      */
     std::pair<bool, Time> timeout() const noexcept;
 
+#if LIBUV_VERSION_AT_LEAST(1,39,0)
     /**
     * @brief Returns the amount of time the event loop has been idle. The call
-    * is thread safe.
+    * is thread safe. Requires libuv 1.39.0+.
     * @return The accumulated time spent idle.
     */
     Time idleTime() const noexcept;
+#endif
 
     /**
      * @brief Returns the current timestamp in milliseconds.

--- a/src/uvw/process.h
+++ b/src/uvw/process.h
@@ -25,8 +25,10 @@ enum class UVProcessFlags: std::underlying_type_t<uv_process_flags> {
     WINDOWS_VERBATIM_ARGUMENTS = UV_PROCESS_WINDOWS_VERBATIM_ARGUMENTS,
     DETACHED = UV_PROCESS_DETACHED,
     WINDOWS_HIDE = UV_PROCESS_WINDOWS_HIDE,
+#if LIBUV_VERSION_AT_LEAST(1,24,0)
     WINDOWS_HIDE_CONSOLE = UV_PROCESS_WINDOWS_HIDE_CONSOLE,
-    WINDOWS_HIDE_GUI = UV_PROCESS_WINDOWS_HIDE_GUI
+    WINDOWS_HIDE_GUI = UV_PROCESS_WINDOWS_HIDE_GUI,
+#endif
 };
 
 
@@ -37,7 +39,9 @@ enum class UVStdIOFlags: std::underlying_type_t<uv_stdio_flags> {
     INHERIT_STREAM = UV_INHERIT_STREAM,
     READABLE_PIPE = UV_READABLE_PIPE,
     WRITABLE_PIPE = UV_WRITABLE_PIPE,
-    OVERLAPPED_PIPE = UV_OVERLAPPED_PIPE
+#if LIBUV_VERSION_AT_LEAST(1,21,0)
+    OVERLAPPED_PIPE = UV_OVERLAPPED_PIPE,
+#endif
 };
 
 
@@ -149,8 +153,8 @@ public:
      * * `ProcessHandle::Process::WINDOWS_VERBATIM_ARGUMENTS`
      * * `ProcessHandle::Process::DETACHED`
      * * `ProcessHandle::Process::WINDOWS_HIDE`
-     * * `ProcessHandle::Process::WINDOWS_HIDE_CONSOLE`
-     * * `ProcessHandle::Process::WINDOWS_HIDE_GUI`
+     * * `ProcessHandle::Process::WINDOWS_HIDE_CONSOLE` (requires libuv 1.24.0+)
+     * * `ProcessHandle::Process::WINDOWS_HIDE_GUI` (requires libuv 1.24.0+)
      *
      * See the official
      * [documentation](http://docs.libuv.org/en/v1.x/process.html#c.uv_process_flags)
@@ -172,7 +176,7 @@ public:
      * * `ProcessHandle::StdIO::INHERIT_STREAM`
      * * `ProcessHandle::StdIO::READABLE_PIPE`
      * * `ProcessHandle::StdIO::WRITABLE_PIPE`
-     * * `ProcessHandle::StdIO::OVERLAPPED_PIPE`
+     * * `ProcessHandle::StdIO::OVERLAPPED_PIPE` (requires libuv 1.21.0+)
      *
      * See the official
      * [documentation](http://docs.libuv.org/en/v1.x/process.html#c.uv_stdio_flags)
@@ -203,7 +207,7 @@ public:
      * * `ProcessHandle::StdIO::INHERIT_STREAM`
      * * `ProcessHandle::StdIO::READABLE_PIPE`
      * * `ProcessHandle::StdIO::WRITABLE_PIPE`
-     * * `ProcessHandle::StdIO::OVERLAPPED_PIPE`
+     * * `ProcessHandle::StdIO::OVERLAPPED_PIPE` (requires libuv 1.21.0+)
      *
      * Default file descriptors are:
      *     * `uvw::StdIN` for `stdin`

--- a/src/uvw/tcp.cpp
+++ b/src/uvw/tcp.cpp
@@ -96,9 +96,11 @@ UVW_INLINE void TCPHandle::connect(const sockaddr &addr) {
 }
 
 
+#if LIBUV_VERSION_AT_LEAST(1,32,0)
 UVW_INLINE void TCPHandle::closeReset() {
     invoke(&uv_tcp_close_reset, get(), &this->closeCallback);
 }
+#endif
 
 
 // explicit instantiations

--- a/src/uvw/tcp.h
+++ b/src/uvw/tcp.h
@@ -211,18 +211,20 @@ public:
     template<typename I = IPv4>
     void connect(Addr addr);
 
+#if LIBUV_VERSION_AT_LEAST(1,32,0)
     /**
      * @brief Resets a TCP connection by sending a RST packet.
      *
      * This is accomplished by setting the `SO_LINGER` socket option with a
      * linger interval of zero and then calling `close`.<br/>
      * Due to some platform inconsistencies, mixing of `shutdown` and
-     * `closeReset` calls is not allowed.
+     * `closeReset` calls is not allowed.  Requires libuv 1.32.0+.
      *
      * A CloseEvent event is emitted when the connection has been reset.<br/>
      * An ErrorEvent event is emitted in case of errors.
      */
     void closeReset();
+#endif
 
 private:
     enum { DEFAULT, FLAGS } tag;

--- a/src/uvw/thread.cpp
+++ b/src/uvw/thread.cpp
@@ -39,10 +39,12 @@ UVW_INLINE bool Thread::run() noexcept {
 }
 
 
+#if LIBUV_VERSION_AT_LEAST(1,26,0)
 UVW_INLINE bool Thread::run(Flags<Options> opts, std::size_t stack) noexcept {
     uv_thread_options_t params{static_cast<unsigned int>(opts), stack};
     return (0 == uv_thread_create_ex(get(), &params, &createCallback, this));
 }
+#endif
 
 
 UVW_INLINE bool Thread::join() noexcept {

--- a/src/uvw/thread.h
+++ b/src/uvw/thread.h
@@ -18,10 +18,12 @@ namespace uvw {
 namespace details {
 
 
+#if LIBUV_VERSION_AT_LEAST(1,26,0)
 enum class UVThreadCreateFlags: std::underlying_type_t<uv_thread_create_flags> {
     THREAD_NO_FLAGS = UV_THREAD_NO_FLAGS,
     THREAD_HAS_STACK_SIZE = UV_THREAD_HAS_STACK_SIZE
 };
+#endif
 
 
 }
@@ -52,7 +54,9 @@ class Thread final: public UnderlyingType<Thread, uv_thread_t> {
     static void createCallback(void *arg);
 
 public:
+#if LIBUV_VERSION_AT_LEAST(1,26,0)
     using Options = details::UVThreadCreateFlags;
+#endif
     using Task = InternalTask;
     using Type = uv_thread_t;
 
@@ -80,6 +84,7 @@ public:
      */
     bool run() noexcept;
 
+#if LIBUV_VERSION_AT_LEAST(1,26,0)
     /**
      * @brief Creates a new thread.
      *
@@ -91,9 +96,12 @@ public:
      * be used (it behaves as if the flag was not set). Other values will be
      * rounded up to the nearest page boundary.
      *
+     * Requires libuv 1.26.0+
+     *
      * @return True in case of success, false otherwise.
      */
     bool run(Flags<Options> opts, std::size_t stack = {}) noexcept;
+#endif
 
     /**
      * @brief Joins with a terminated thread.

--- a/src/uvw/timer.cpp
+++ b/src/uvw/timer.cpp
@@ -44,9 +44,11 @@ UVW_INLINE TimerHandle::Time TimerHandle::repeat() {
 }
 
 
+#if LIBUV_VERSION_AT_LEAST(1,40,0)
 UVW_INLINE TimerHandle::Time TimerHandle::dueIn() {
     return Time{uv_timer_get_due_in(get())};
 }
+#endif
 
 
 }

--- a/src/uvw/timer.h
+++ b/src/uvw/timer.h
@@ -95,6 +95,7 @@ public:
      */
     Time repeat();
 
+#if LIBUV_VERSION_AT_LEAST(1,40,0)
     /**
      * @brief Gets the timer due value.
      * 
@@ -103,6 +104,7 @@ public:
      * @return The timer due value or 0 if it has expired.
      */
     Time dueIn();
+#endif
 };
 
 

--- a/src/uvw/tty.cpp
+++ b/src/uvw/tty.cpp
@@ -58,6 +58,7 @@ UVW_INLINE WinSize TTYHandle::getWinSize() {
 }
 
 
+#if LIBUV_VERSION_AT_LEAST(1,33,0)
 UVW_INLINE void TTYHandle::vtermState(TTYHandle::VTermState s) const noexcept {
     switch(s) {
         case VTermState::SUPPORTED:
@@ -75,6 +76,7 @@ UVW_INLINE TTYHandle::VTermState TTYHandle::vtermState() const noexcept {
     uv_tty_get_vterm_state(&state);
     return VTermState{state};
 }
+#endif
 
 
 }

--- a/src/uvw/tty.h
+++ b/src/uvw/tty.h
@@ -27,10 +27,12 @@ enum class UVTTYModeT: std::underlying_type_t<uv_tty_mode_t> {
 };
 
 
+#if LIBUV_VERSION_AT_LEAST(1,33,0)
 enum class UVTTYVTermStateT: std::underlying_type_t<uv_tty_vtermstate_t> {
     SUPPORTED = UV_TTY_SUPPORTED,
     UNSUPPORTED = UV_TTY_UNSUPPORTED
 };
+#endif
 
 
 }
@@ -59,7 +61,9 @@ class TTYHandle final: public StreamHandle<TTYHandle, uv_tty_t> {
 
 public:
     using Mode = details::UVTTYModeT;
+#if LIBUV_VERSION_AT_LEAST(1,33,0)
     using VTermState = details::UVTTYVTermStateT;
+#endif
 
     explicit TTYHandle(ConstructorAccess ca, std::shared_ptr<Loop> ref, FileHandle desc, bool readable);
 
@@ -99,12 +103,13 @@ public:
      */
     WinSize getWinSize();
 
+#if LIBUV_VERSION_AT_LEAST(1,33,0)
     /**
      * @brief Controls whether console virtual terminal sequences are processed
      * by the library or console.
      *
      * This function is only meaningful on Windows systems. On Unix it is
-     * silently ignored.
+     * silently ignored. Requires libuv 1.33.0+.
      *
      * Available states are:
      *
@@ -123,7 +128,7 @@ public:
      * @brief Gets the current state of whether console virtual terminal
      * sequences are handled by the library or the console.
      *
-     * This function is not implemented on Unix.
+     * This function is not implemented on Unix. Requires libuv 1.33.0+.
      *
      * Available states are:
      *
@@ -137,6 +142,7 @@ public:
      * @return The current state.
      */
     VTermState vtermState() const noexcept;
+#endif
 
 private:
     std::shared_ptr<details::ResetModeMemo> memo;

--- a/src/uvw/udp.cpp
+++ b/src/uvw/udp.cpp
@@ -45,6 +45,7 @@ UVW_INLINE void UDPHandle::bind(const sockaddr &addr, Flags<UDPHandle::Bind> opt
 }
 
 
+#if LIBUV_VERSION_AT_LEAST(1,27,0)
 UVW_INLINE void UDPHandle::connect(const sockaddr &addr) {
     invoke(&uv_udp_connect, get(), &addr);
 }
@@ -73,6 +74,7 @@ template<typename I>
 UVW_INLINE Addr UDPHandle::peer() const noexcept {
     return details::address<I>(&uv_udp_getpeername, get());
 }
+#endif
 
 
 template<typename I>
@@ -253,6 +255,7 @@ UVW_INLINE void UDPHandle::stop() {
 }
 
 
+#if LIBUV_VERSION_AT_LEAST(1,19,0)
 UVW_INLINE size_t UDPHandle::sendQueueSize() const noexcept {
     return uv_udp_get_send_queue_size(get());
 }
@@ -261,6 +264,7 @@ UVW_INLINE size_t UDPHandle::sendQueueSize() const noexcept {
 UVW_INLINE size_t UDPHandle::sendQueueCount() const noexcept {
     return uv_udp_get_send_queue_count(get());
 }
+#endif
 
 
 // explicit instantiations

--- a/src/uvw/udp.cpp
+++ b/src/uvw/udp.cpp
@@ -269,6 +269,7 @@ UVW_INLINE size_t UDPHandle::sendQueueCount() const noexcept {
 
 // explicit instantiations
 #ifdef UVW_AS_LIB
+#if LIBUV_VERSION_AT_LEAST(1,27,0)
 template void UDPHandle::connect<IPv4>(std::string, unsigned int);
 template void UDPHandle::connect<IPv6>(std::string, unsigned int);
 
@@ -277,6 +278,7 @@ template void UDPHandle::connect<IPv6>(Addr);
 
 template Addr UDPHandle::peer<IPv4>() const noexcept;
 template Addr UDPHandle::peer<IPv6>() const noexcept;
+#endif
 
 template void UDPHandle::bind<IPv4>(std::string, unsigned int, Flags<Bind>);
 template void UDPHandle::bind<IPv6>(std::string, unsigned int, Flags<Bind>);

--- a/src/uvw/udp.h
+++ b/src/uvw/udp.h
@@ -599,6 +599,7 @@ private:
 
 // (extern) explicit instantiations
 #ifdef UVW_AS_LIB
+#if LIBUV_VERSION_AT_LEAST(1,27,0)
 extern template void UDPHandle::connect<IPv4>(std::string, unsigned int);
 extern template void UDPHandle::connect<IPv6>(std::string, unsigned int);
 
@@ -607,6 +608,7 @@ extern template void UDPHandle::connect<IPv6>(Addr);
 
 extern template Addr UDPHandle::peer<IPv4>() const noexcept;
 extern template Addr UDPHandle::peer<IPv6>() const noexcept;
+#endif
 
 extern template void UDPHandle::bind<IPv4>(std::string, unsigned int, Flags<Bind>);
 extern template void UDPHandle::bind<IPv6>(std::string, unsigned int, Flags<Bind>);

--- a/src/uvw/udp.h
+++ b/src/uvw/udp.h
@@ -46,9 +46,15 @@ enum class UVUDPFlags: std::underlying_type_t<uv_udp_flags> {
     IPV6ONLY = UV_UDP_IPV6ONLY,
     UDP_PARTIAL = UV_UDP_PARTIAL,
     REUSEADDR = UV_UDP_REUSEADDR,
+#if LIBUV_VERSION_AT_LEAST(1,35,0)
     UDP_MMSG_CHUNK = UV_UDP_MMSG_CHUNK,
+#endif
+#if LIBUV_VERSION_AT_LEAST(1,40,0)
     UDP_MMSG_FREE = UV_UDP_MMSG_FREE,
-    UDP_RECVMMSG = UV_UDP_RECVMMSG
+#endif
+#if LIBUV_VERSION_AT_LEAST(1,37,0)
+    UDP_RECVMMSG = UV_UDP_RECVMMSG,
+#endif
 };
 
 
@@ -150,9 +156,9 @@ public:
      * * `UDPHandle::Bind::IPV6ONLY`
      * * `UDPHandle::Bind::UDP_PARTIAL`
      * * `UDPHandle::Bind::REUSEADDR`
-     * * `UDPHandle::Bind::UDP_MMSG_CHUNK`
-     * * `UDPHandle::Bind::UDP_MMSG_FREE`
-     * * `UDPHandle::Bind::UDP_RECVMMSG`
+     * * `UDPHandle::Bind::UDP_MMSG_CHUNK` (libuv 1.35.0+)
+     * * `UDPHandle::Bind::UDP_MMSG_FREE` (libuv 1.40.0+)
+     * * `UDPHandle::Bind::UDP_RECVMMSG` (libuv 1.37.0+)
      *
      * See the official
      * [documentation](http://docs.libuv.org/en/v1.x/udp.html#c.uv_udp_flags)
@@ -163,6 +169,7 @@ public:
      */
     void bind(const sockaddr &addr, Flags<Bind> opts = Flags<Bind>{});
 
+#if LIBUV_VERSION_AT_LEAST(1,27,0)
     /**
      * @brief Associates the handle to a remote address and port (either IPv4 or
      * IPv6).
@@ -171,6 +178,7 @@ public:
      * destination.<br/>
      * Trying to call this function on an already connected handle isn't
      * allowed.
+     * Requires libuv 1.27.0+.
      *
      * An ErrorEvent event is emitted in case of errors during the connection.
      *
@@ -226,6 +234,7 @@ public:
      */
     template<typename I = IPv4>
     Addr peer() const noexcept;
+#endif
 
     /**
      * @brief Binds the UDP handle to an IP address and port.
@@ -235,9 +244,9 @@ public:
      * * `UDPHandle::Bind::IPV6ONLY`
      * * `UDPHandle::Bind::UDP_PARTIAL`
      * * `UDPHandle::Bind::REUSEADDR`
-     * * `UDPHandle::Bind::UDP_MMSG_CHUNK`
-     * * `UDPHandle::Bind::UDP_MMSG_FREE`
-     * * `UDPHandle::Bind::UDP_RECVMMSG`
+     * * `UDPHandle::Bind::UDP_MMSG_CHUNK` (libuv 1.35.0+)
+     * * `UDPHandle::Bind::UDP_MMSG_FREE` (libuv 1.40.0+)
+     * * `UDPHandle::Bind::UDP_RECVMMSG` (libuv 1.37.0+)
      *
      * See the official
      * [documentation](http://docs.libuv.org/en/v1.x/udp.html#c.uv_udp_flags)
@@ -258,9 +267,9 @@ public:
      * * `UDPHandle::Bind::IPV6ONLY`
      * * `UDPHandle::Bind::UDP_PARTIAL`
      * * `UDPHandle::Bind::REUSEADDR`
-     * * `UDPHandle::Bind::UDP_MMSG_CHUNK`
-     * * `UDPHandle::Bind::UDP_MMSG_FREE`
-     * * `UDPHandle::Bind::UDP_RECVMMSG`
+     * * `UDPHandle::Bind::UDP_MMSG_CHUNK` (libuv 1.35.0+)
+     * * `UDPHandle::Bind::UDP_MMSG_FREE` (libuv 1.40.0+)
+     * * `UDPHandle::Bind::UDP_RECVMMSG` (libuv 1.37.0+)
      *
      * See the official
      * [documentation](http://docs.libuv.org/en/v1.x/udp.html#c.uv_udp_flags)
@@ -558,20 +567,23 @@ public:
      */
     void stop();
 
+#if LIBUV_VERSION_AT_LEAST(1,19,0)
     /**
      * @brief Gets the number of bytes queued for sending.
      *
-     * It strictly shows how much information is currently queued.
+     * It strictly shows how much information is currently queued.  Requires libuv 1.19.0+.
      *
      * @return Number of bytes queued for sending.
      */
     size_t sendQueueSize() const noexcept;
 
     /**
-     * @brief Number of send requests currently in the queue awaiting to be processed.
+     * @brief Number of send requests currently in the queue awaiting to be processed. libuv
+     * 1.19.0+.
      * @return Number of send requests currently in the queue.
      */
     size_t sendQueueCount() const noexcept;
+#endif
 
 private:
     enum { DEFAULT, FLAGS } tag{DEFAULT};

--- a/src/uvw/util.cpp
+++ b/src/uvw/util.cpp
@@ -45,6 +45,7 @@ UVW_INLINE Passwd::operator bool() const noexcept {
 }
 
 
+#if LIBUV_VERSION_AT_LEAST(1,25,0)
 UVW_INLINE UtsName::UtsName(std::shared_ptr<uv_utsname_t> utsname)
     : utsname{utsname}
 {}
@@ -68,6 +69,7 @@ UVW_INLINE std::string UtsName::version() const noexcept {
 UVW_INLINE std::string UtsName::machine() const noexcept {
     return utsname ? utsname->machine : "";
 }
+#endif
 
 
 UVW_INLINE PidType Utilities::OS::pid() noexcept {
@@ -105,11 +107,13 @@ UVW_INLINE std::string Utilities::OS::hostname() noexcept {
 }
 
 
+#if LIBUV_VERSION_AT_LEAST(1,25,0)
 UVW_INLINE UtsName Utilities::OS::uname() noexcept {
     auto ptr = std::make_shared<uv_utsname_t>();
     uv_os_uname(ptr.get());
     return ptr;
 }
+#endif
 
 
 UVW_INLINE Passwd Utilities::OS::passwd() noexcept {
@@ -124,6 +128,7 @@ UVW_INLINE Passwd Utilities::OS::passwd() noexcept {
 }
 
 
+#if LIBUV_VERSION_AT_LEAST(1,23,0)
 UVW_INLINE int Utilities::osPriority(PidType pid) {
     int prio = 0;
 
@@ -138,6 +143,7 @@ UVW_INLINE int Utilities::osPriority(PidType pid) {
 UVW_INLINE bool Utilities::osPriority(PidType pid, int prio) {
     return 0 == uv_os_setpriority(pid, prio);
 }
+#endif
 
 
 UVW_INLINE HandleType Utilities::guessHandle(HandleCategory category) noexcept {
@@ -288,9 +294,11 @@ UVW_INLINE uint64_t Utilities::totalMemory() noexcept {
 }
 
 
+#if LIBUV_VERSION_AT_LEAST(1,29,0)
 UVW_INLINE uint64_t Utilities::constrainedMemory() noexcept {
     return uv_get_constrained_memory();
 }
+#endif
 
 
 UVW_INLINE double Utilities::uptime() noexcept {
@@ -331,16 +339,20 @@ UVW_INLINE bool Utilities::chdir(const std::string &dir) noexcept {
 }
 
 
+#if LIBUV_VERSION_AT_LEAST(1,28,0)
 UVW_INLINE TimeVal64 Utilities::timeOfDay() noexcept {
     uv_timeval64_t ret;
     uv_gettimeofday(&ret);
     return ret;
 }
+#endif
 
 
+#if LIBUV_VERSION_AT_LEAST(1,34,0)
 UVW_INLINE void Utilities::sleep(unsigned int msec) noexcept {
     uv_sleep(msec);
 }
+#endif
 
 
 }

--- a/src/uvw/util.h
+++ b/src/uvw/util.h
@@ -11,6 +11,7 @@
 #include <memory>
 #include <array>
 #include <uv.h>
+#include "config.h"
 
 
 namespace uvw {
@@ -197,12 +198,16 @@ constexpr FileHandle StdERR{2}; /*!< Placeholder for stderr descriptor. */
 
 using TimeSpec = uv_timespec_t; /*!< Library equivalent for uv_timespec_t. */
 using Stat = uv_stat_t; /*!< Library equivalent for uv_stat_t. */
+#if LIBUV_VERSION_AT_LEAST(1,31,0)
 using Statfs = uv_statfs_t; /*!< Library equivalent for uv_statfs_t. */
+#endif
 using Uid = uv_uid_t; /*!< Library equivalent for uv_uid_t. */
 using Gid = uv_gid_t; /*!< Library equivalent for uv_gid_t. */
 
 using TimeVal = uv_timeval_t; /*!< Library equivalent for uv_timeval_t. */
-using TimeVal64 = uv_timeval64_t; /*!< Library equivalent for uv_timeval64_t. */
+#if LIBUV_VERSION_AT_LEAST(1,28,0)
+using TimeVal64 = uv_timeval64_t; /*!< Library equivalent for uv_timeval64_t. (requires libuv 1.28.0+) */
+#endif
 using RUsage = uv_rusage_t; /*!< Library equivalent for uv_rusage_t. */
 
 
@@ -258,12 +263,15 @@ private:
 };
 
 
+#if LIBUV_VERSION_AT_LEAST(1,25,0)
 /**
  * @brief Utility class.
  *
  * This class can be used to get name and information about the current kernel.
  * The populated data includes the operating system name, release, version, and
  * machine.
+ *
+ * Requires libuv 1.25.0+.
  *
  * \sa Utilities::uname
  */
@@ -297,6 +305,7 @@ struct UtsName {
 private:
     std::shared_ptr<uv_utsname_t> utsname;
 };
+#endif
 
 
 /**
@@ -522,6 +531,7 @@ struct Utilities {
          */
         static bool env(const std::string &name, const std::string &value) noexcept;
 
+#if LIBUV_VERSION_AT_LEAST(1,31,0)
         /**
          * @brief Retrieves all environment variables and iterates them.
          *
@@ -529,6 +539,7 @@ struct Utilities {
          * form of `std::string_view`s.<br/>
          * The signature of the function call operator must be such that it
          * accepts two parameters, the name and the value of the i-th variable.
+         * Requires libuv 1.31.0+.
          *
          * @tparam Func Type of a function object to which to pass environment
          * variables.
@@ -553,6 +564,7 @@ struct Utilities {
 
             return ret;
         }
+#endif
 
         /**
          * @brief Returns the hostname.
@@ -560,6 +572,7 @@ struct Utilities {
          */
         static std::string hostname() noexcept;
 
+#if LIBUV_VERSION_AT_LEAST(1,25,0)
         /**
          * @brief Gets name and information about the current kernel.
          *
@@ -570,6 +583,7 @@ struct Utilities {
          * @return Name and information about the current kernel.
          */
         static UtsName uname() noexcept;
+#endif
 
         /**
          * @brief Gets a subset of the password file entry.
@@ -586,11 +600,13 @@ struct Utilities {
         static Passwd passwd() noexcept;
     };
 
+#if LIBUV_VERSION_AT_LEAST(1,23,0)
     /**
      * @brief Retrieves the scheduling priority of a process.
      *
      * The returned value is between -20 (high priority) and 19 (low priority).
      * A value that is out of range is returned in case of errors.
+     * Requires libuv 1.23.0+
      *
      * @note
      * On Windows, the result won't equal necessarily the exact value of the
@@ -606,6 +622,7 @@ struct Utilities {
      *
      * The returned value range is between -20 (high priority) and 19 (low
      * priority).
+     * Requires libuv 1.23.0+
      *
      * @note
      * On Windows, the priority is mapped to a Windows priority class. When
@@ -617,6 +634,7 @@ struct Utilities {
      * @return True in case of success, false otherwise.
      */
     static bool osPriority(PidType pid, int prio);
+#endif
 
     /**
      * @brief Gets the type of the handle given a category.
@@ -750,6 +768,7 @@ struct Utilities {
      */
     static uint64_t totalMemory() noexcept;
 
+#if LIBUV_VERSION_AT_LEAST(1,29,0)
     /**
      * @brief Gets the amount of memory available to the process (in bytes).
      *
@@ -758,10 +777,12 @@ struct Utilities {
      * unknown, `0` is returned.<br/>
      * Note that it is not unusual for this value to be less than or greater
      * than `totalMemory`.
+     * Requires libuv 1.29.0+.
      *
      * @return Amount of memory available to the process.
      */
     static uint64_t constrainedMemory() noexcept;
+#endif
 
     /**
      * @brief Gets the current system uptime.
@@ -806,18 +827,22 @@ struct Utilities {
      */
     static bool chdir(const std::string &dir) noexcept;
 
+#if LIBUV_VERSION_AT_LEAST(1,28,0)
     /**
      * @brief Cross-platform implementation of
-     * [`gettimeofday`](https://linux.die.net/man/2/gettimeofday)
+     * [`gettimeofday`](https://linux.die.net/man/2/gettimeofday) (libuv 1.28.0+)
      * @return The current time.
      */
     static TimeVal64 timeOfDay() noexcept;
+#endif
 
+#if LIBUV_VERSION_AT_LEAST(1,34,0)
     /**
-     * @brief Causes the calling thread to sleep for a while.
+     * @brief Causes the calling thread to sleep for a while. (libuv 1.34.0+)
      * @param msec Number of milliseconds to sleep.
      */
     static void sleep(unsigned int msec) noexcept;
+#endif
 };
 
 

--- a/test/uvw/fs_req.cpp
+++ b/test/uvw/fs_req.cpp
@@ -707,6 +707,9 @@ TEST(FsReq, ChownSync) {
 
 
 TEST(FsReq, Lchown) {
+#if !LIBUV_VERSION_AT_LEAST(1,21,0)
+    GTEST_SKIP() << "Requires libuv 1.21.0+";
+#else
     const std::string filename = std::string{TARGET_FS_REQ_DIR} + std::string{"/test.file"};
 
     auto loop = uvw::Loop::getDefault();
@@ -743,10 +746,14 @@ TEST(FsReq, Lchown) {
     loop->run();
 
     ASSERT_TRUE(checkFsLChownEvent);
+#endif
 }
 
 
 TEST(FsReq, LchownSync) {
+#if !LIBUV_VERSION_AT_LEAST(1,21,0)
+    GTEST_SKIP() << "Requires libuv 1.21.0+";
+#else
     const std::string filename = std::string{TARGET_FS_REQ_DIR} + std::string{"/test.file"};
 
     auto loop = uvw::Loop::getDefault();
@@ -764,9 +771,13 @@ TEST(FsReq, LchownSync) {
     ASSERT_TRUE(fsReq->lchownSync(filename, uid, gid));
 
     loop->run();
+#endif
 }
 
 TEST(FsReq, ReadDir) {
+#if !LIBUV_VERSION_AT_LEAST(1,28,0)
+    GTEST_SKIP() << "Requires libuv 1.28.0+";
+#else
     const std::string dir_name = std::string{TARGET_FS_REQ_DIR};
 
     auto loop = uvw::Loop::getDefault();
@@ -805,9 +816,13 @@ TEST(FsReq, ReadDir) {
     ASSERT_TRUE(checkFsCloseDirEvent);
     ASSERT_TRUE(checkFsReadDirEvent);
     ASSERT_TRUE(checkFsOpenDirEvent);
+#endif
 }
 
 TEST(FsReq, ReadDirSync) {
+#if !LIBUV_VERSION_AT_LEAST(1,28,0)
+    GTEST_SKIP() << "Requires libuv 1.28.0+";
+#else
     const std::string dir_name = std::string{TARGET_FS_REQ_DIR};
 
     auto loop = uvw::Loop::getDefault();
@@ -821,4 +836,5 @@ TEST(FsReq, ReadDirSync) {
     ASSERT_TRUE(fsReq->closedirSync());
 
     loop->run();
+#endif
 }

--- a/test/uvw/loop.cpp
+++ b/test/uvw/loop.cpp
@@ -88,9 +88,13 @@ TEST(Loop, Configure) {
 
 
 TEST(Loop, IdleTime) {
+#if !LIBUV_VERSION_AT_LEAST(1,39,0)
+    GTEST_SKIP() << "Requires libuv 1.39.0+";
+#else
     auto loop = uvw::Loop::create();
     loop->configure(uvw::Loop::Configure::IDLE_TIME);
     ASSERT_EQ(loop->idleTime().count(), 0u);
+#endif
 }
 
 


### PR DESCRIPTION
One thing that is fairly important for our project is to be able to be packaged and run on moderately older Linux distributions -- we build packages for Ubuntu versions between 18.04 and current and Debian 10 and up.  We try, when possible, to link against system libraries whenever possible because it keeps the onus for security updates in dependent libraries on the distribution itself (and, secondarily, keeps binaries smaller).  One of the obstacles I've run into in converting our codebase from libuv to uvw, however, is that uvw is currently tightly coupled to the latest libuv version—even if I don't need newer capabilities from libuv—which effectively makes it impossible to use with an older, system-provided libuv.

Hence this PR: this adds version macros around the features in newer libuv versions so that they are only available if the libuv headers in use are sufficiently up-to-date; that lets one use current uvw (with fixes, features, etc.) with an older libuv (as long as you don't need the features only available with a newer libuv version, of course).  It also adds the required libuv version into the docs for the gated features.

I went back as far as libuv 1.16.0 (because that introduced OS-dependent fs open macros which would be a nuisance to support with earlier libuv versions), which allows successful builds on Ubuntu 18.04 and newer (and also coincides with when Ubuntu started shipping a C++17 capable compiler).