### PR TITLE
export `uvwConfig` to build a uvw submodule statically

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -199,6 +199,7 @@ if(FETCH_LIBUV AND BUILD_UVW_LIBS)
     endif()
     
 endif(FETCH_LIBUV AND BUILD_UVW_LIBS)
+export(EXPORT uvwConfig)
 
 ### Testing
 


### PR DESCRIPTION
(Otherwise, the caller will receive an error like:

```
CMake Error in CMakeLists.txt:
  export called with target "..." which requires target "uvw" that is
  not in any export set.
```
