### PR TITLE
Include cstdint where uintX_t is used

### DIFF
--- a/src/uvw/emitter.h
+++ b/src/uvw/emitter.h
@@ -3,6 +3,7 @@
 
 #include <algorithm>
 #include <cstddef>
+#include <cstdint>
 #include <functional>
 #include <list>
 #include <memory>

--- a/src/uvw/thread.h
+++ b/src/uvw/thread.h
@@ -2,6 +2,7 @@
 #define UVW_THREAD_INCLUDE_H
 
 #include <cstddef>
+#include <cstdint>
 #include <memory>
 #include <string>
 #include <type_traits>

--- a/src/uvw/timer.h
+++ b/src/uvw/timer.h
@@ -1,6 +1,7 @@
 #ifndef UVW_TIMER_INCLUDE_H
 #define UVW_TIMER_INCLUDE_H
 
+#include <cstdint>
 #include <chrono>
 #include <uv.h>
 #include "handle.hpp"

--- a/src/uvw/type_info.hpp
+++ b/src/uvw/type_info.hpp
@@ -2,6 +2,7 @@
 #define UVW_TYPE_INFO_INCLUDE_HPP
 
 #include <cstddef>
+#include <cstdint>
 #include <string_view>
 
 namespace uvw {

--- a/src/uvw/util.h
+++ b/src/uvw/util.h
@@ -3,6 +3,7 @@
 
 #include <array>
 #include <cstddef>
+#include <cstdint>
 #include <memory>
 #include <string>
 #include <string_view>


### PR DESCRIPTION
Use namespaced version of stdint.h header, which defines int32_t, uint32_t and similar types.

This fixes build error when building flamethrower package with recent release of uvw.
Bug: https://bugzilla.redhat.com/show_bug.cgi?id=2171490