### PR TITLE
Add Vcpkg badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![Build Status](https://github.com/skypjack/uvw/workflows/build/badge.svg)](https://github.com/skypjack/uvw/actions)
 [![Coverage](https://codecov.io/gh/skypjack/uvw/branch/master/graph/badge.svg)](https://codecov.io/gh/skypjack/uvw)
 [![Documentation](https://img.shields.io/badge/docs-doxygen-blue)](https://skypjack.github.io/uvw/)
+[![Vcpkg port](https://img.shields.io/vcpkg/v/uvw)](https://vcpkg.link/ports/uvw)
 [![Gitter chat](https://badges.gitter.im/skypjack/uvw.png)](https://gitter.im/skypjack/uvw)
 [![Donate](https://img.shields.io/badge/Donate-PayPal-green.svg)](https://www.paypal.me/skypjack)
 


### PR DESCRIPTION
I'm the author of [vcpkg.link](https://vcpkg.link) and currently trying to improve the discoverability of Vcpkg ports since it helps other developers to integrate libraries into their projects.

This PR aims to add a fresh new [shields.io](https://shields.io) badge (https://github.com/badges/shields/pull/8923) that provides at a glance in the README which version of uvw is available on [Vcpkg](https://vcpkg.link/ports/uvw).

![Vcpkg Shields.io Badge](https://img.shields.io/vcpkg/v/uvw)