### PR TITLE
avoid cmake complaining about using VERSION keyword

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ cmake-build-debug/
 .idea/
 .vs/
 .vscode/
+.cache/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -186,12 +186,13 @@ install(
 #
 # Install targets
 #
-
-set_target_properties(
-    uvw PROPERTIES
-    VERSION ${UVW_VERSION_MAJOR}.${UVW_VERSION_MINOR}.${UVW_VERSION_PATCH}
-    SOVERSION ${UVW_VERSION_MAJOR}
-)
+if (BUILD_UVW_LIBS)
+    set_target_properties(
+        uvw PROPERTIES
+        VERSION ${UVW_VERSION_MAJOR}.${UVW_VERSION_MINOR}.${UVW_VERSION_PATCH}
+        SOVERSION ${UVW_VERSION_MAJOR}
+    )
+endif()
 install(
     EXPORT uvwConfig 
     NAMESPACE uvw:: 


### PR DESCRIPTION
	[cmake] CMake Error at CMakeLists.txt:190 (set_target_properties):
	[cmake]   INTERFACE_LIBRARY targets may only have whitelisted properties.  The
	[cmake]   property "VERSION" is not allowed.