### PR TITLE
Do not fail unit test because cpu speed 0

### DIFF
--- a/test/uvw/util.cpp
+++ b/test/uvw/util.cpp
@@ -60,7 +60,8 @@ TEST(Util, Utilities) {
 
     ASSERT_NE(cpuInfo.size(), decltype(cpuInfo.size()){0});
     ASSERT_FALSE(cpuInfo[0].model.empty());
-    ASSERT_NE(cpuInfo[0].speed, decltype(cpuInfo[0].speed){0});
+    /* returns 0 on unsupported architectures */
+    ASSERT_GE(cpuInfo[0].speed, decltype(cpuInfo[0].speed){0});
 
     auto interfaceAddresses = uvw::utilities::interface_addresses();
 


### PR DESCRIPTION
Some architectures do not have implemented obtaining cpu speed. They return 0 for undefined value. Pass the test with any non-negative value.

Resolves #252