### PR TITLE
fix ambiguous overloaded from c++20 with explicit cast

### DIFF
--- a/src/uvw/process.cpp
+++ b/src/uvw/process.cpp
@@ -82,7 +82,7 @@ UVW_INLINE process_handle &process_handle::stdio(file_handle fd, stdio_flags fla
     auto actual = uvw::file_handle{fd};
 
     auto it = std::find_if(po_fd_stdio.begin(), po_fd_stdio.end(), [actual](auto &&container) {
-        return container.data.fd == actual;
+        return container.data.fd == static_cast<uvw::file_handle::Type>(actual);
     });
 
     if(it == po_fd_stdio.cend()) {


### PR DESCRIPTION
Hello, the same problem as #278 

Starting with c++20, comparison operators can now be reversed and lead to ambiguous overloads. (cf https://brevzin.github.io/c++/2019/07/28/comparisons-cpp20/#reversing-primary-operators, https://stackoverflow.com/questions/65946930/ambiguous-overloaded-operator-c20)

An minimal reproductive example: https://godbolt.org/z/jTP469TMf

Fix it with an explicit type conversion

relative issue from an other project: https://github.com/boostorg/date_time/issues/132