### PR TITLE
Fix compile errors caused by ambiguous naming of poll_event in poll_handle

### DIFF
--- a/src/uvw/poll.cpp
+++ b/src/uvw/poll.cpp
@@ -20,7 +20,7 @@ UVW_INLINE void poll_handle::start_callback(uv_poll_t *hndl, int status, int eve
     if(poll_handle &poll = *(static_cast<poll_handle *>(hndl->data)); status) {
         poll.publish(error_event{status});
     } else {
-        poll.publish(poll_event{poll_event(events)});
+        poll.publish(poll_event{details::uvw_poll_event(events)});
     }
 }
 
@@ -32,7 +32,7 @@ UVW_INLINE int poll_handle::init() {
     }
 }
 
-UVW_INLINE int poll_handle::start(poll_handle::poll_event flags) {
+UVW_INLINE int poll_handle::start(details::uvw_poll_event flags) {
     return uv_poll_start(raw(), static_cast<uv_poll_event>(flags), &start_callback);
 }
 

--- a/src/uvw/poll.cpp
+++ b/src/uvw/poll.cpp
@@ -20,7 +20,7 @@ UVW_INLINE void poll_handle::start_callback(uv_poll_t *hndl, int status, int eve
     if(poll_handle &poll = *(static_cast<poll_handle *>(hndl->data)); status) {
         poll.publish(error_event{status});
     } else {
-        poll.publish(poll_event{details::uvw_poll_event(events)});
+        poll.publish(poll_event{poll_event_flags(events)});
     }
 }
 
@@ -32,7 +32,7 @@ UVW_INLINE int poll_handle::init() {
     }
 }
 
-UVW_INLINE int poll_handle::start(details::uvw_poll_event flags) {
+UVW_INLINE int poll_handle::start(poll_event_flags flags) {
     return uv_poll_start(raw(), static_cast<uv_poll_event>(flags), &start_callback);
 }
 

--- a/src/uvw/poll.h
+++ b/src/uvw/poll.h
@@ -60,6 +60,7 @@ class poll_handle final: public handle<poll_handle, uv_poll_t, poll_event> {
     static void start_callback(uv_poll_t *hndl, int status, int events);
 
 public:
+    using poll_event_flags = details::uvw_poll_event;
 
     explicit poll_handle(loop::token token, std::shared_ptr<loop> ref, int desc);
     explicit poll_handle(loop::token token, std::shared_ptr<loop> ref, os_socket_handle sock);
@@ -89,7 +90,7 @@ public:
      * @param flags The events to which the caller is interested.
      * @return Underlying return value.
      */
-    int start(details::uvw_poll_event flags);
+    int start(poll_event_flags flags);
 
     /**
      * @brief Stops polling the file descriptor.

--- a/src/uvw/poll.h
+++ b/src/uvw/poll.h
@@ -56,11 +56,10 @@ struct poll_event {
  * [documentation](http://docs.libuv.org/en/v1.x/poll.html)
  * for further details.
  */
-class poll_handle final: public handle<poll_handle, uv_poll_t, details::uvw_poll_event> {
+class poll_handle final: public handle<poll_handle, uv_poll_t, poll_event> {
     static void start_callback(uv_poll_t *hndl, int status, int events);
 
 public:
-    using poll_event = details::uvw_poll_event;
 
     explicit poll_handle(loop::token token, std::shared_ptr<loop> ref, int desc);
     explicit poll_handle(loop::token token, std::shared_ptr<loop> ref, os_socket_handle sock);
@@ -90,7 +89,7 @@ public:
      * @param flags The events to which the caller is interested.
      * @return Underlying return value.
      */
-    int start(poll_event flags);
+    int start(details::uvw_poll_event flags);
 
     /**
      * @brief Stops polling the file descriptor.


### PR DESCRIPTION
The line 
```
using poll_event = details::uvw_poll_event;
```

created an ambiguous alias with the same name as the  `struct poll_event`.

And `poll_handle` should be inheriting `handle<poll_handle, uv_poll_t, poll_event>` instead of `handle<poll_handle, uv_poll_t, details::uvw_poll_event>` if I'm understanding correctly. Otherwise `on<uvw::poll_event>()` doesn't work.