### PR TITLE
fix undefined uint32_t error on 2.12.1 under GCC 13 

### DIFF
--- a/src/uvw/type_info.hpp
+++ b/src/uvw/type_info.hpp
@@ -1,7 +1,7 @@
 #ifndef UVW_TYPE_INFO_INCLUDE_HPP
 #define UVW_TYPE_INFO_INCLUDE_HPP
 
-#include <cstddef>
+#include <cstdint>
 #include <string_view>
 
 namespace uvw {


### PR DESCRIPTION
uvw 2.12.1 currently doesn't compile with GCC 13 (Fedora 38) because type_info.hpp doesn't have correct include for standard integers.

```
/home/fcelda/devel/uvw/src/uvw/type_info.hpp:17:37: error: ‘uint32_t’ in namespace ‘std’ does not name a type; did you mean ‘wint_t’?
   17 | [[nodiscard]] static constexpr std::uint32_t fnv1a(const char *curr) noexcept {
      |                                     ^~~~~~~~
      |                                     wint_t
```

Standard integers are defined in [cstdint](https://en.cppreference.com/w/cpp/header/cstdint). The removed header [cstdef](https://en.cppreference.com/w/cpp/header/cstddef) seems unused.