### PR TITLE
Provide custom read buffer allocators for handle objects

### DIFF
--- a/src/uvw/handle.hpp
+++ b/src/uvw/handle.hpp
@@ -243,6 +243,8 @@ public:
         uv_fileno(as_uv_handle(), &fd);
         return fd;
     }
+
+    std::function<void(uv_buf_t *, std::size_t, T &)> allocator = details::default_allocator<T>;
 };
 
 } // namespace uvw

--- a/src/uvw/stream.h
+++ b/src/uvw/stream.h
@@ -228,7 +228,7 @@ public:
      * @return Underlying return value.
      */
     int read() {
-        return uv_read_start(as_uv_stream(), &details::common_alloc_callback, &read_callback);
+        return uv_read_start(as_uv_stream(), &details::alloc_callback<T>, &read_callback);
     }
 
     /**

--- a/src/uvw/udp.cpp
+++ b/src/uvw/udp.cpp
@@ -198,7 +198,7 @@ UVW_INLINE int udp_handle::try_send(socket_address addr, char *data, unsigned in
 }
 
 UVW_INLINE int udp_handle::recv() {
-    return uv_udp_recv_start(raw(), &details::common_alloc_callback, &recv_callback);
+    return uv_udp_recv_start(raw(), &details::alloc_callback<udp_handle>, &recv_callback);
 }
 
 UVW_INLINE int udp_handle::stop() {

--- a/src/uvw/util.cpp
+++ b/src/uvw/util.cpp
@@ -54,11 +54,6 @@ UVW_INLINE std::string uts_name::machine() const noexcept {
 
 namespace details {
 
-UVW_INLINE void common_alloc_callback(uv_handle_t *, std::size_t suggested, uv_buf_t *buf) {
-    auto size = static_cast<unsigned int>(suggested);
-    *buf = uv_buf_init(new char[size], size);
-}
-
 UVW_INLINE sockaddr ip_addr(const char *addr, unsigned int port) {
     if(sockaddr_in addr_in; uv_ip4_addr(addr, port, &addr_in) == 0) {
         return reinterpret_cast<const sockaddr &>(addr_in);

--- a/src/uvw/util.h
+++ b/src/uvw/util.h
@@ -270,7 +270,17 @@ std::string try_read(F &&f, Args &&...args) noexcept {
     return str;
 }
 
-void common_alloc_callback(uv_handle_t *, std::size_t suggested, uv_buf_t *buf);
+template<class T>
+void default_allocator(uv_buf_t *buf, std::size_t suggested, T &) {
+    auto size = static_cast<unsigned int>(suggested);
+    *buf = uv_buf_init(new char[size], size);
+}
+
+template<class T>
+void alloc_callback(uv_handle_t *hndl, std::size_t suggested, uv_buf_t *buf) {
+    T &ref = *(static_cast<T *>(hndl->data));
+    ref.allocator(buf, suggested, ref);
+}
 
 sockaddr ip_addr(const char *addr, unsigned int port);
 socket_address sock_addr(const sockaddr_in &addr);


### PR DESCRIPTION
I add one field `allocator` for handle objects, that is called as `uv_alloc_cb` in `uv_udp_recv_start` or `uv_recv_start`. Maybe allocator field should be private/protected or whatever. #289 #267