### PR TITLE
loop: rename variable to fix `-Wshadow` warning

### DIFF
--- a/src/uvw/loop.h
+++ b/src/uvw/loop.h
@@ -278,9 +278,9 @@ public:
      */
     template<typename Func>
     void walk(Func callback) {
-        auto func = [](uv_handle_t *hndl, void *func) {
+        auto func = [](uv_handle_t *hndl, void *callback_func) {
             if(hndl->data) {
-                auto &cb = *static_cast<Func *>(func);
+                auto &cb = *static_cast<Func *>(callback_func);
 
                 switch(utilities::guess_handle(handle_category{hndl->type})) {
                 case handle_type::ASYNC:


### PR DESCRIPTION
Fixes the following compiler `-Wshadow` warning by renaming a variable:

```
In file included from /uvw/src/uvw/fs.h:11,
                 from /uvw/test/uvw/file_req_sendfile.cpp:3:
/uvw/src/uvw/loop.h: In lambda function:
/uvw/src/uvw/loop.h:281:49: warning: declaration of ‘func’ shadows a previous local [-Wshadow]
  281 |         auto func = [](uv_handle_t *hndl, void *func) {
      |                                           ~~~~~~^~~~
/home/alois/Documents/uvw/src/uvw/loop.h:281:14: note: shadowed declaration is here
  281 |         auto func = [](uv_handle_t *hndl, void *func) {
      |              ^~~~
```