### PR TITLE
util: fix `-Wsign-conversion` in ip_addr()

### DIFF
--- a/src/uvw/util.cpp
+++ b/src/uvw/util.cpp
@@ -60,9 +60,12 @@ UVW_INLINE void common_alloc_callback(uv_handle_t *, std::size_t suggested, uv_b
 }
 
 UVW_INLINE sockaddr ip_addr(const char *addr, unsigned int port) {
-    if(sockaddr_in addr_in; uv_ip4_addr(addr, port, &addr_in) == 0) {
+    // explicitly cast to avoid `-Wsign-conversion` warnings
+    // libuv internally just casts to an `unsigned short` anyway
+    auto signed_port = static_cast<int>(port);
+    if(sockaddr_in addr_in; uv_ip4_addr(addr, signed_port, &addr_in) == 0) {
         return reinterpret_cast<const sockaddr &>(addr_in);
-    } else if(sockaddr_in6 addr_in6; uv_ip6_addr(addr, port, &addr_in6) == 0) {
+    } else if(sockaddr_in6 addr_in6; uv_ip6_addr(addr, signed_port, &addr_in6) == 0) {
         return reinterpret_cast<const sockaddr &>(addr_in6);
     }
 


### PR DESCRIPTION
Explicitly cast `unsigned int port` to an `signed int` to supress a `-Wsign-conversion` warning in `uvw::details::ip_addr()`.

We don't need to worry about too much about overflowing, since `libuv` internally just converts everything back to an `unsigned short` later, see https://github.com/libuv/libuv/blob/b3759772d20e89537980d5d43a01ce4c2f2535a8/src/uv-common.c#L257

### Original warning

```
/uvw/src/uvw/util.cpp: In function ‘sockaddr uvw::details::ip_addr(const char*, unsigned int)’:
/uvw/src/uvw/util.cpp:63:47: warning: conversion to ‘int’ from ‘unsigned int’ may change the sign of the result [-Wsign-conversion]
   63 |     if(sockaddr_in addr_in; uv_ip4_addr(addr, port, &addr_in) == 0) {
      |                                               ^~~~
/uvw/src/uvw/util.cpp:65:56: warning: conversion to ‘int’ from ‘unsigned int’ may change the sign of the result [-Wsign-conversion]
   65 |     } else if(sockaddr_in6 addr_in6; uv_ip6_addr(addr, port, &addr_in6) == 0) {
      |                                                        ^~~~
```