### PR TITLE
pipe: hide `uvw::pipe_handle::connect()` `-Wsign-conversion` warning

### DIFF
--- a/src/uvw/pipe.cpp
+++ b/src/uvw/pipe.cpp
@@ -31,7 +31,8 @@ UVW_INLINE int pipe_handle::connect(const std::string &name, const bool no_trunc
     connect->on<error_event>(listener);
     connect->on<connect_event>(listener);
 
-    return connect->connect(&uv_pipe_connect2, raw(), name.data(), name.size(), no_truncate * UV_PIPE_NO_TRUNCATE);
+    unsigned int flags = no_truncate * UV_PIPE_NO_TRUNCATE;
+    return connect->connect(&uv_pipe_connect2, raw(), name.data(), name.size(), flags);
 }
 
 UVW_INLINE std::string pipe_handle::sock() const noexcept {


### PR DESCRIPTION
Hide the following `-Wsign-conversion` warning in `uvw::pipe_handle::connect()` by explicitly passing an `unsigned int`.

```
/uvw/src/uvw/stream.h:56:48: warning: conversion to ‘unsigned int’ from ‘int’ may change the sign of the result [-Wsign-conversion]
   56 |         return this->leak_if(std::forward<F>(f)(raw(), std::forward<Args>(args)..., &connect_callback));
```