### PR TITLE
tty: remove unnecessary semi-colon

### DIFF
--- a/src/uvw/tty.cpp
+++ b/src/uvw/tty.cpp
@@ -22,7 +22,7 @@ UVW_INLINE std::shared_ptr<details::reset_mode_memo> tty_handle::mode_memo_handl
     auto shared = weak.lock();
     if(!shared) { weak = shared = std::make_shared<details::reset_mode_memo>(); }
     return shared;
-};
+}
 
 UVW_INLINE int tty_handle::init() {
     return leak_if(uv_tty_init(parent().raw(), raw(), fd, rw));


### PR DESCRIPTION
There's an unneeded semi-colon after the definition of `tty_handle::mode_memo_handler()` that may cause a compiler to print a warning:

### GNU C++ compiler

This no longer seems to appear on newer G++ compilers, only older ones (like GCC-10).

```
In file included from /home/runner/work/uvw/uvw/src/uvw/tty.h:143,
                 from /home/runner/work/uvw/uvw/src/uvw.hpp:24,
                 from /home/runner/work/uvw/uvw/test/main.cpp:5:
/home/runner/work/uvw/uvw/src/uvw/tty.cpp:25:2: error: extra ‘;’ [-Werror=pedantic]
   25 | };
```

Logs taken from https://github.com/aloisklink/uvw/actions/runs/5952382537/job/16144246200

### Clang

```
/home/runner/work/uvw/uvw/src/uvw/tty.cpp:25:2: error: extra ';' outside of a function is incompatible with C++98 [-Werror,-Wc++98-compat-extra-semi]
};
```