### PR TITLE
type_info: avoid gcc-7 `-Wsign-conversion warning`

### DIFF
--- a/src/uvw/type_info.hpp
+++ b/src/uvw/type_info.hpp
@@ -20,7 +20,8 @@ namespace internal {
     auto value = offset;
 
     while(*curr != 0) {
-        value = (value ^ static_cast<std::uint32_t>(*(curr++))) * prime;
+        auto curr_val_int = static_cast<std::uint32_t>(*(curr++));
+        value = (value ^ curr_val_int) * prime;
     }
 
     return value;


### PR DESCRIPTION
On GCC 7.5.0, the current `uvw::internal::fnv1a()` function throws a `-Wsign-conversion` warning, despite us having an explicit cast.

```
src/uvw/type_info.hpp: In function 'constexpr uint32_t uvw::internal::fnv1a(const char*)':
src/uvw/type_info.hpp:24:26: warning: conversion to 'unsigned int' from 'char' may change the sign of the result [-Wsign-conversion]
         value = (value ^ static_cast<std::uint32_t>(curr_val)) * prime;
                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

This seems to be a bug in GCC 7.5.0, since newer versions of GCC are fine with it (including GCC 8). Moving the cast to another line fixes the warning, and it should all be compiled down to the same machine code anyway.