### PR TITLE
uv_type: make `~uv_type()` destructor protected

### DIFF
--- a/src/uvw/uv_type.hpp
+++ b/src/uvw/uv_type.hpp
@@ -79,6 +79,9 @@ struct uv_type {
         return &resource;
     }
 
+protected:
+    ~uv_type() = default;
+
 private:
     std::shared_ptr<loop> owner;
     U resource;


### PR DESCRIPTION
Make the destructor for `uv_type` `protected`, in order to the fix the `-Wnon-virtual-dtor` warnings:

```
‘struct uvw::uv_type<uv_async_s>’ has virtual functions and accessible non-virtual destructor [-Werror=non-virtual-dtor]
```

This prevents a potential memory leak when calling the `~uv_type()` destructor (instead of the `~resource()` destructor) on a `uvw::resource`.

### Example of memory leak

As an example, the code below currently works (casting a pointer to a subclass of `uvw::uv_type` to `uvw::uv_type`, but it causes a memory leak, since only the `uvw::uv_type` destructor is called. Doing this is now forbidden.

```c++
uvw::resource<...>* will_leak;
auto abc = std::unique_ptr<uvw::uv_type>(will_leak);
```

---

**BREAKING CHANGE**: This change may break the `uvw` ABI, since we're changing the destructor from `public` to `protected`, which is fine on some platforms, but it's not guaranteed to be binary compatible. It also breaks the API, as some code that compiled previously (but with memory leaks), will now no longer compile.

**I'd recommend waiting to merge this until the next MAJOR of `uvw` version (e.g. `uvw` v4).**