### PR TITLE
Check for GCC/Clang compiler warnings in Ubuntu GitHub Actions CI

### DIFF
--- a/.github/workflows/build-ubuntu-20.04.yml
+++ b/.github/workflows/build-ubuntu-20.04.yml
@@ -27,12 +27,11 @@ jobs:
         sudo apt-get update --fix-missing
         sudo apt install -y ${{ matrix.compiler.pkg }}-${{ matrix.compiler.version }}
     - name: Compile tests
-      working-directory: build
       env:
         CXX: ${{ matrix.compiler.exe }}-${{ matrix.compiler.version }}
       run: |
-        cmake ${{ matrix.mode }} -DBUILD_TESTING=ON -Dlibuv_buildtests=OFF ..
-        make -j2
+        cmake ${{ matrix.mode }} --preset ci-ubuntu
+        cmake --build build/ --parallel 2
     - name: Run tests
       working-directory: build
       env:

--- a/.github/workflows/build-ubuntu-latest.yml
+++ b/.github/workflows/build-ubuntu-latest.yml
@@ -26,12 +26,11 @@ jobs:
         sudo apt-get update --fix-missing
         sudo apt install -y ${{ matrix.compiler.pkg }}-${{ matrix.compiler.version }}
     - name: Compile tests
-      working-directory: build
       env:
         CXX: ${{ matrix.compiler.exe }}-${{ matrix.compiler.version }}
       run: |
-        cmake ${{ matrix.mode }} -DBUILD_TESTING=ON -Dlibuv_buildtests=OFF ..
-        make -j2
+        cmake ${{ matrix.mode }} --preset ci-ubuntu
+        cmake --build build/ --parallel 2
     - name: Run tests
       working-directory: build
       env:

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,59 @@
+{
+  "version": 2,
+  "cmakeMinimumRequired": {
+    "major": 3,
+    "minor": 13,
+    "patch": 0
+  },
+  "configurePresets": [
+    {
+      "name": "cmake-pedantic",
+      "description": "Enables all CMake warnings.`",
+      "hidden": true,
+      "warnings": {
+        "dev": true,
+        "deprecated": true,
+        "uninitialized": true,
+        "unusedCli": true,
+        "systemVars": false
+      }
+    },
+    {
+      "name": "dev-mode",
+      "hidden": true,
+      "description": "Common (non-OS specific) mode for development",
+      "inherits": "cmake-pedantic",
+      "cacheVariables": {
+        "BUILD_TESTING": true,
+        "libuv_buildtests": false
+      }
+    },
+    {
+      "name": "flags-linux",
+      "hidden": true,
+      "description": "Compiler flags for GNU and Clang compilers. When compiling in DEBUG mode, all warnings will be converted into errors.",
+      "cacheVariables": {
+        "CMAKE_CXX_FLAGS": "-Wall -Wextra -Wpedantic -Wconversion -Wsign-conversion -Wcast-qual -Wformat=2 -Wundef -Wshadow -Wcast-align -Wunused -Wnull-dereference -Wimplicit-fallthrough -Woverloaded-virtual -Wnon-virtual-dtor -Wold-style-cast",
+        "CMAKE_CXX_FLAGS_DEBUG": "-Werror"
+      }
+    },
+    {
+      "name": "ci-linux",
+      "generator": "Unix Makefiles",
+      "hidden": true,
+      "inherits": ["flags-linux"],
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug"
+      }
+    },
+    {
+      "name": "ci-build",
+      "binaryDir": "${sourceDir}/build",
+      "hidden": true
+    },
+    {
+      "name": "ci-ubuntu",
+      "inherits": ["ci-build", "ci-linux", "dev-mode"]
+    }
+  ]
+}


### PR DESCRIPTION
Add a [`CMakePresets.json`][1] file that contains `ci-ubuntu` preset. This preset contains most of the recommended compiler warnings from the [`cmake-init`][2] project, with the following changes:
  - I had to remove the `-Wdouble-promotion` and `-Werror=float-equal` flags since there are issues within the GTest headers.
  - For compatibility with g++-7, which doesn't support this flag, `-Wextra-semi` was removed.
  - I also had to remove some of the following flags like: `-fstack-protector-strong -fstack-clash-protection`. These flags cause errors in Clang v10, and to be honest, with stuff like address sanitizer, we probably don't need them.

I've also set the `"CMAKE_CXX_FLAGS_DEBUG": "-Werror"` variable when running on `ubuntu` in GitHub Actions. This will make the `ubuntu` build fail whenever any warnings are seen in the code, so you'll instantly spot it whenever somebody tries to add code that has warnings to this project. This should prevent issues like https://github.com/skypjack/uvw/issues/294 from happening in the future.

[1]: https://cmake.org/cmake/help/latest/manual/cmake-presets.7.html
[2]: https://github.com/friendlyanon/cmake-init/blob/aa42211c79ab5117b05a2d9f795427f078a0a3d5/cmake-init/templates/common/CMakePresets.json#L88

---

~I've left this PR as a draft, since the CI currently fails, but after the following PRs are merged, this CI job should work~ All of these PRs have now been merged, so CI passes:
  - https://github.com/skypjack/uvw/pull/296
  - https://github.com/skypjack/uvw/pull/297
  - https://github.com/skypjack/uvw/pull/298
  - https://github.com/skypjack/uvw/pull/299
  - https://github.com/skypjack/uvw/pull/300
  - https://github.com/skypjack/uvw/pull/301
  - https://github.com/skypjack/uvw/pull/302
  - https://github.com/skypjack/uvw/pull/303