### PR TITLE
build: add initial meson support

### DIFF
--- a/.github/workflows/build-meson.yml
+++ b/.github/workflows/build-meson.yml
@@ -1,0 +1,25 @@
+name: build-meson
+
+on: [push, pull_request]
+
+jobs:
+  meson:
+    timeout-minutes: 60
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Meson
+        env:
+          DEBIAN_FRONTEND: noninteractive
+        run: |
+          sudo apt-get update --fix-missing
+          sudo apt-get install -y meson
+      - name: Meson Build (shared)
+        run: |
+          meson setup build
+          meson compile -C build
+      - name: Meson Build (static)
+        run: |
+          rm -rf build/
+          meson setup build --default-library=static
+          meson compile -C build

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ libraries are compiled through `CMake`.
 
 You can use `uvw` with [meson](https://mesonbuild.com/) by simply adding it to
 your `subprojects` directory in your project. Currently, `uvw` is not available
-with `meson wrap`, but this will change with the release of `uvw` 3.2.1.
+with `meson wrap`, but this will change with the release of `uvw` 3.3.x.
 
 To compile `uvw` from source without using it as a subproject, in the `uvw`
 source directory, run:

--- a/README.md
+++ b/README.md
@@ -109,9 +109,12 @@ libraries are compiled through `CMake`.
 
 ## Meson
 
-You can use `uvw` with [meson](https://mesonbuild.com/) by simply adding it to your `subprojects` directory in your project. Currently, `uvw` is not available with `meson wrap`, but this will change with the release of `uvw` 3.2.1.
+You can use `uvw` with [meson](https://mesonbuild.com/) by simply adding it to
+your `subprojects` directory in your project. Currently, `uvw` is not available
+with `meson wrap`, but this will change with the release of `uvw` 3.2.1.
 
-To compile `uvw` from source without using it as a subproject, in the `uvw` source directory, run:
+To compile `uvw` from source without using it as a subproject, in the `uvw`
+source directory, run:
 
 * `$ meson setup build`
   * If you want a static library, add `--default-library=static`

--- a/README.md
+++ b/README.md
@@ -93,7 +93,8 @@ exist a valid `libuv` wrapper in C++. That's all.
 To be able to use `uvw`, users must provide the following system-wide tools:
 
 * A full-featured compiler that supports at least C++17.
-* `libuv` (which version depends on the tag of `uvw` in use).
+* `libuv` (which version depends on the tag of `uvw` in use)
+  *  If you use `meson`, libuv will be downloaded for you
 
 The requirements below are mandatory to compile the tests and to extract the
 documentation:
@@ -105,6 +106,17 @@ Note that `libuv` is part of the dependencies of the project and may be cloned
 by `CMake` in some cases (see below for further details).<br/>
 Because of that, users don't have to install it to run the tests or when `uvw`
 libraries are compiled through `CMake`.
+
+## Meson
+
+You can use `uvw` with [meson](https://mesonbuild.com/) by simply adding it to your `subprojects` directory in your project. Currently, `uvw` is not available with `meson wrap`, but this will change with the release of `uvw` 3.2.1.
+
+To compile `uvw` from source without using it as a subproject, in the `uvw` source directory, run:
+
+* `$ meson setup build`
+  * If you want a static library, add `--default-library=static`
+* `$ cd build`
+* `$ meson compile`
 
 ## Library
 

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ libraries are compiled through `CMake`.
 
 You can use `uvw` with [meson](https://mesonbuild.com/) by simply adding it to
 your `subprojects` directory in your project. Currently, `uvw` is not available
-with `meson wrap`, but this will change with the release of `uvw` 3.3.x.
+with `meson wrap`, but this will change with the release of `uvw` 3.4.x.
 
 To compile `uvw` from source without using it as a subproject, in the `uvw`
 source directory, run:

--- a/meson.build
+++ b/meson.build
@@ -1,6 +1,6 @@
 project(
   'uvw',
-  ['c', 'cpp'],
+  'cpp',
   version: '3.3.0',
   license: 'MIT',
   default_options: ['cpp_std=c++17'],
@@ -34,10 +34,6 @@ sources = [
   'src/uvw/work.cpp',
 ]
 
-uvw_header_only_dep = declare_dependency(
-  include_directories: 'src',
-)
-
 uvw_lib = library(
   'uvw', sources,
   include_directories: 'src',
@@ -55,9 +51,3 @@ uvw_dep = declare_dependency(
 if meson.version().version_compare('>=0.54.0')
   meson.override_dependency('uvw', uvw_dep)
 endif
-
-pkg_mod = import('pkgconfig')
-pkg_mod.generate(uvw_lib,
-  name: 'uvw',
-  filebase: 'uvw',
-)

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,63 @@
+project(
+  'uvw',
+  ['c', 'cpp'],
+  version: '3.3.0',
+  license: 'MIT',
+  default_options: ['cpp_std=c++17'],
+)
+
+libuv_dep = dependency('libuv', version: '1.46.0')
+
+sources = [
+  'src/uvw/async.cpp',
+  'src/uvw/check.cpp',
+  'src/uvw/dns.cpp',
+  'src/uvw/emitter.cpp',
+  'src/uvw/fs.cpp',
+  'src/uvw/fs_event.cpp',
+  'src/uvw/fs_poll.cpp',
+  'src/uvw/idle.cpp',
+  'src/uvw/lib.cpp',
+  'src/uvw/loop.cpp',
+  'src/uvw/pipe.cpp',
+  'src/uvw/poll.cpp',
+  'src/uvw/prepare.cpp',
+  'src/uvw/process.cpp',
+  'src/uvw/signal.cpp',
+  'src/uvw/stream.cpp',
+  'src/uvw/tcp.cpp',
+  'src/uvw/thread.cpp',
+  'src/uvw/timer.cpp',
+  'src/uvw/tty.cpp',
+  'src/uvw/udp.cpp',
+  'src/uvw/util.cpp',
+  'src/uvw/work.cpp',
+]
+
+uvw_header_only_dep = declare_dependency(
+  include_directories: 'src',
+)
+
+uvw_lib = library(
+  'uvw', sources,
+  include_directories: 'src',
+  dependencies: [libuv_dep],
+  cpp_args: ['-DUVW_AS_LIB'],
+  install: true,
+)
+
+uvw_dep = declare_dependency(
+  include_directories: ['src'],
+  dependencies: [libuv_dep],
+  link_with: [uvw_lib],
+)
+
+if meson.version().version_compare('>=0.54.0')
+  meson.override_dependency('uvw', uvw_dep)
+endif
+
+pkg_mod = import('pkgconfig')
+pkg_mod.generate(uvw_lib,
+  name: 'uvw',
+  filebase: 'uvw',
+)

--- a/subprojects/.gitignore
+++ b/subprojects/.gitignore
@@ -1,0 +1,3 @@
+*
+!.gitignore
+!*.wrap

--- a/subprojects/libuv.wrap
+++ b/subprojects/libuv.wrap
@@ -1,0 +1,13 @@
+[wrap-file]
+directory = libuv-v1.46.0
+source_url = https://dist.libuv.org/dist/v1.46.0/libuv-v1.46.0.tar.gz
+source_filename = libuv-v1.46.0.tar.gz
+source_hash = 111f83958b9fdc65f1489195d25f342b9f7a3e683140c60e62c00fbaccddddce
+patch_filename = libuv_1.46.0-1_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/libuv_1.46.0-1/get_patch
+patch_hash = 41b1834129f13efcb4a94a137335eb85fe0662509010c157617954d2feb20ac8
+source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/libuv_1.46.0-1/libuv-v1.46.0.tar.gz
+wrapdb_version = 1.46.0-1
+
+[provide]
+libuv = libuv_dep


### PR DESCRIPTION
This PR adds initial support for the [meson](https://mesonbuild.com/) build system. Currently set up to work as a shared/static library, since that works best with meson's dependency system for libuv.

This should be able to be backported to the current release as well if desired.