### PR TITLE
build(meson): bump libuv to 1.48.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,8 +104,7 @@ libraries are compiled through `CMake`.
 ## Meson
 
 You can use `uvw` with [meson](https://mesonbuild.com/) by simply adding it to
-your `subprojects` directory in your project. Currently, `uvw` is not available
-with `meson wrap`, but this will change with the release of `uvw` 3.4.x.
+your `subprojects` directory in your project.
 
 To compile `uvw` from source without using it as a subproject, in the `uvw`
 source directory, run:

--- a/meson.build
+++ b/meson.build
@@ -6,7 +6,7 @@ project(
   default_options: ['cpp_std=c++17'],
 )
 
-libuv_dep = dependency('libuv', version: '1.46.0')
+libuv_dep = dependency('libuv', version: '1.48.0', required: true)
 
 sources = [
   'src/uvw/async.cpp',
@@ -35,7 +35,8 @@ sources = [
 ]
 
 uvw_lib = library(
-  'uvw', sources,
+  'uvw',
+  sources,
   include_directories: 'src',
   dependencies: [libuv_dep],
   cpp_args: ['-DUVW_AS_LIB'],

--- a/subprojects/libuv.wrap
+++ b/subprojects/libuv.wrap
@@ -1,13 +1,13 @@
 [wrap-file]
-directory = libuv-v1.46.0
-source_url = https://dist.libuv.org/dist/v1.46.0/libuv-v1.46.0.tar.gz
-source_filename = libuv-v1.46.0.tar.gz
-source_hash = 111f83958b9fdc65f1489195d25f342b9f7a3e683140c60e62c00fbaccddddce
-patch_filename = libuv_1.46.0-1_patch.zip
-patch_url = https://wrapdb.mesonbuild.com/v2/libuv_1.46.0-1/get_patch
-patch_hash = 41b1834129f13efcb4a94a137335eb85fe0662509010c157617954d2feb20ac8
-source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/libuv_1.46.0-1/libuv-v1.46.0.tar.gz
-wrapdb_version = 1.46.0-1
+directory = libuv-v1.48.0
+source_url = https://dist.libuv.org/dist/v1.48.0/libuv-v1.48.0.tar.gz
+source_filename = libuv-v1.48.0.tar.gz
+source_hash = 7f1db8ac368d89d1baf163bac1ea5fe5120697a73910c8ae6b2fffb3551d59fb
+patch_filename = libuv_1.48.0-1_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/libuv_1.48.0-1/get_patch
+patch_hash = 27b18917c914a5d6dfb459073710e9bfb6b2962d69d4e0bad5bc7b1173482be7
+source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/libuv_1.48.0-1/libuv-v1.48.0.tar.gz
+wrapdb_version = 1.48.0-1
 
 [provide]
 libuv = libuv_dep


### PR DESCRIPTION
- ran `meson wrap update` to update subproject version
- updated meson.build to reflect new version number