### PR TITLE
Make error_event copy assignable

### DIFF
--- a/src/uvw/emitter.h
+++ b/src/uvw/emitter.h
@@ -70,7 +70,7 @@ struct error_event {
     explicit operator bool() const noexcept;
 
 private:
-    const int ec;
+    int ec;
 };
 
 /**


### PR DESCRIPTION
Please consider this PR which makes the `error_event` struct copy-assignable. The reason it's not right now is because the `ec` member variable is marked const. This makes is harder to work with this struct.