### PR TITLE
fs_event: enable bit operations for the uvw_fs_event enum

### DIFF
--- a/src/uvw/fs_event.h
+++ b/src/uvw/fs_event.h
@@ -23,7 +23,8 @@ enum class uvw_fs_event_flags : std::underlying_type_t<uv_fs_event_flags> {
 
 enum class uvw_fs_event : std::underlying_type_t<uv_fs_event> {
     RENAME = UV_RENAME,
-    CHANGE = UV_CHANGE
+    CHANGE = UV_CHANGE,
+    UVW_ENUM = 0
 };
 
 } // namespace details


### PR DESCRIPTION
This PR adds the _UVW_ENUM_ member to the enum class _uvw_fs_event_ to enables the bitwise operations over the type.

The libuv documentation says that the flags are a bit mask:

> The events parameter is an ORed mask of [uv_fs_event](https://docs.libuv.org/en/v1.x/fs_event.html#c.uv_fs_event) elements.

-- https://docs.libuv.org/en/v1.x/fs_event.html#c.uv_fs_event_cb:
