### PR TITLE
thread: add an internal flag to track if a thread is running

### DIFF
--- a/src/uvw/thread.h
+++ b/src/uvw/thread.h
@@ -146,6 +146,7 @@ public:
 private:
     std::shared_ptr<void> data;
     task func;
+    bool active;
 };
 
 /**


### PR DESCRIPTION
This adds an active flag to uvw::thread to track whether the thread has been started or not. It prevents running the threads multiple times and also makes sure the thread is joined exactly once.

This should also fix the current unit test failure in the main branch:

```
 19/27 Test #20: uvw_thread .......................***Failed    0.01 sec
Running main() from /home/runner/work/uvw/uvw/build/_deps/googletest-src/googletest/src/gtest_main.cc
[==========] Running 4 tests from 3 test suites.
[----------] Global test environment set-up.
[----------] 1 test from Thread
[ RUN      ] Thread.Run
==3574==ERROR: AddressSanitizer: Joining already joined thread, aborting.
```

The reason for the ASAN failure is that the thread is joined explicitly and then again in the thread destructor:
- https://github.com/skypjack/uvw/blob/a43ad541a19e729b4584b541b63e9d7ed458da37/test/uvw/thread.cpp#L16
- https://github.com/skypjack/uvw/blob/a43ad541a19e729b4584b541b63e9d7ed458da37/src/uvw/thread.ipp#L48