### PR TITLE
Add include directories to vendored uv target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,9 +91,19 @@ function(fetch_libuv)
         if(UVW_BUILD_SHARED_LIB)
             add_library(uv::uv-shared ALIAS uv)
             set_target_properties(uv PROPERTIES POSITION_INDEPENDENT_CODE 1)
+            target_include_directories(
+                uv
+                INTERFACE
+                    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/uvw/uv/include>
+            )
         else()
             add_library(uv::uv-static ALIAS uv_a)
             set_target_properties(uv_a PROPERTIES POSITION_INDEPENDENT_CODE 1)
+            target_include_directories(
+                uv_a
+                INTERFACE
+                    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/uvw/uv/include>
+            )
         endif()
     endif(UVW_FETCH_LIBUV)
 endfunction()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,7 +68,7 @@ if(UVW_USE_CLANG_TIDY)
 endif()
 
 # Required minimal libuv version
-set(UVW_LIBUV_VERSION 1.50.0)
+set(UVW_LIBUV_VERSION 1.52.1)
 
 function(fetch_libuv)
     if (UVW_FETCH_LIBUV)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -218,7 +218,7 @@ endif()
 
 install(
     EXPORT uvwConfig 
-    NAMESPACE uvw:: 
+    NAMESPACE uvw::
     DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/uvw
 )
 

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ To use `uvw` as a compiled library, set the `UVW_BUILD_LIBS` options in cmake
 before including the project.<br/>
 This option triggers the generation of a targets named
 `uvw::uvw-static`. The matching version of `libuv` is also
-compiled and exported as `uv::uv-static` for convenience.
+compiled and exported as `uvw::uv-a` for convenience.
 
 In case you don't use or don't want to use `CMake`, you can still compile all
 `.cpp` files and include all `.h` files to get the job done. In this case, users


### PR DESCRIPTION
Hi,

I am using uvw and find the vendored uv static lib handy. However I was not able to simply just link to uvw and uv as it would result in missing include issues, because the uv directory is put into a nested include directory.

I am not sure if this was intentional or a mistake - if it was me I would have uv and uvw header directories at the same level and not nested. In any case, this fixes the missing include error.

In addition, any of the `uv::` namespace does not seem to be exported either as they are build time aliases. I changed the README to reflect that.

I bumped to latest libuv because I needed TCP keepalive_ex functionality. Let me know if you want me to drop that commit.